### PR TITLE
Add instruction timing model with latency table

### DIFF
--- a/timing/latency/config.go
+++ b/timing/latency/config.go
@@ -1,0 +1,153 @@
+package latency
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// TimingConfig holds latency values for different instruction types.
+// Values are based on Apple M2 microarchitecture estimates.
+type TimingConfig struct {
+	// ALULatency is the execution latency for basic ALU operations
+	// (ADD, SUB, AND, OR, XOR). Default: 1 cycle.
+	ALULatency uint64 `json:"alu_latency"`
+
+	// BranchLatency is the base execution latency for branch instructions.
+	// This does not include misprediction penalty. Default: 1 cycle.
+	BranchLatency uint64 `json:"branch_latency"`
+
+	// BranchMispredictPenalty is the additional cycles lost on branch misprediction.
+	// Default: 12 cycles (typical for modern out-of-order cores).
+	BranchMispredictPenalty uint64 `json:"branch_mispredict_penalty"`
+
+	// LoadLatency is the latency for load operations assuming L1 cache hit.
+	// Default: 4 cycles.
+	LoadLatency uint64 `json:"load_latency"`
+
+	// StoreLatency is the latency for store operations (fire-and-forget to LSQ).
+	// Default: 1 cycle.
+	StoreLatency uint64 `json:"store_latency"`
+
+	// MultiplyLatency is the latency for integer multiply operations.
+	// Default: 3 cycles. (For future MUL instruction support)
+	MultiplyLatency uint64 `json:"multiply_latency"`
+
+	// DivideLatencyMin is the minimum latency for integer divide operations.
+	// Default: 10 cycles. (For future DIV instruction support)
+	DivideLatencyMin uint64 `json:"divide_latency_min"`
+
+	// DivideLatencyMax is the maximum latency for integer divide operations.
+	// Default: 15 cycles. (For future DIV instruction support)
+	DivideLatencyMax uint64 `json:"divide_latency_max"`
+
+	// SyscallLatency is the latency for system call instructions.
+	// Default: 1 cycle (handling is external).
+	SyscallLatency uint64 `json:"syscall_latency"`
+
+	// L1HitLatency is the L1 data cache hit latency.
+	// Default: 4 cycles.
+	L1HitLatency uint64 `json:"l1_hit_latency"`
+
+	// L2HitLatency is the L2 cache hit latency.
+	// Default: 12 cycles.
+	L2HitLatency uint64 `json:"l2_hit_latency"`
+
+	// L3HitLatency is the L3 cache hit latency.
+	// Default: 30 cycles.
+	L3HitLatency uint64 `json:"l3_hit_latency"`
+
+	// MemoryLatency is the main memory access latency.
+	// Default: 150 cycles.
+	MemoryLatency uint64 `json:"memory_latency"`
+}
+
+// DefaultTimingConfig returns a TimingConfig with M2-based default values.
+func DefaultTimingConfig() *TimingConfig {
+	return &TimingConfig{
+		ALULatency:              1,
+		BranchLatency:           1,
+		BranchMispredictPenalty: 12,
+		LoadLatency:             4,
+		StoreLatency:            1,
+		MultiplyLatency:         3,
+		DivideLatencyMin:        10,
+		DivideLatencyMax:        15,
+		SyscallLatency:          1,
+		L1HitLatency:            4,
+		L2HitLatency:            12,
+		L3HitLatency:            30,
+		MemoryLatency:           150,
+	}
+}
+
+// LoadConfig loads a TimingConfig from a JSON file.
+func LoadConfig(path string) (*TimingConfig, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("failed to read timing config file: %w", err)
+	}
+
+	config := DefaultTimingConfig()
+	if err := json.Unmarshal(data, config); err != nil {
+		return nil, fmt.Errorf("failed to parse timing config: %w", err)
+	}
+
+	return config, nil
+}
+
+// SaveConfig writes a TimingConfig to a JSON file.
+func (c *TimingConfig) SaveConfig(path string) error {
+	data, err := json.MarshalIndent(c, "", "  ")
+	if err != nil {
+		return fmt.Errorf("failed to serialize timing config: %w", err)
+	}
+
+	if err := os.WriteFile(path, data, 0644); err != nil {
+		return fmt.Errorf("failed to write timing config file: %w", err)
+	}
+
+	return nil
+}
+
+// Validate checks that all latency values are valid (> 0).
+func (c *TimingConfig) Validate() error {
+	if c.ALULatency == 0 {
+		return fmt.Errorf("alu_latency must be > 0")
+	}
+	if c.BranchLatency == 0 {
+		return fmt.Errorf("branch_latency must be > 0")
+	}
+	if c.LoadLatency == 0 {
+		return fmt.Errorf("load_latency must be > 0")
+	}
+	if c.StoreLatency == 0 {
+		return fmt.Errorf("store_latency must be > 0")
+	}
+	if c.SyscallLatency == 0 {
+		return fmt.Errorf("syscall_latency must be > 0")
+	}
+	if c.DivideLatencyMin > c.DivideLatencyMax {
+		return fmt.Errorf("divide_latency_min must be <= divide_latency_max")
+	}
+	return nil
+}
+
+// Clone returns a deep copy of the TimingConfig.
+func (c *TimingConfig) Clone() *TimingConfig {
+	return &TimingConfig{
+		ALULatency:              c.ALULatency,
+		BranchLatency:           c.BranchLatency,
+		BranchMispredictPenalty: c.BranchMispredictPenalty,
+		LoadLatency:             c.LoadLatency,
+		StoreLatency:            c.StoreLatency,
+		MultiplyLatency:         c.MultiplyLatency,
+		DivideLatencyMin:        c.DivideLatencyMin,
+		DivideLatencyMax:        c.DivideLatencyMax,
+		SyscallLatency:          c.SyscallLatency,
+		L1HitLatency:            c.L1HitLatency,
+		L2HitLatency:            c.L2HitLatency,
+		L3HitLatency:            c.L3HitLatency,
+		MemoryLatency:           c.MemoryLatency,
+	}
+}

--- a/timing/latency/latency.go
+++ b/timing/latency/latency.go
@@ -1,0 +1,119 @@
+// Package latency provides instruction timing models for cycle-accurate simulation.
+//
+// The latency values are based on Apple M2 microarchitecture estimates and
+// can be configured via TimingConfig.
+package latency
+
+import (
+	"github.com/sarchlab/m2sim/insts"
+)
+
+// Table provides instruction latency lookups.
+type Table struct {
+	config *TimingConfig
+}
+
+// NewTable creates a new latency table with default M2 timing values.
+func NewTable() *Table {
+	return &Table{
+		config: DefaultTimingConfig(),
+	}
+}
+
+// NewTableWithConfig creates a new latency table with custom timing configuration.
+func NewTableWithConfig(config *TimingConfig) *Table {
+	return &Table{
+		config: config,
+	}
+}
+
+// GetLatency returns the execution latency in cycles for the given instruction.
+// For variable-latency operations, returns the typical/expected latency.
+func (t *Table) GetLatency(inst *insts.Instruction) uint64 {
+	if inst == nil {
+		return 1
+	}
+
+	switch inst.Op {
+	case insts.OpADD, insts.OpSUB, insts.OpAND, insts.OpORR, insts.OpEOR:
+		return t.config.ALULatency
+
+	case insts.OpB, insts.OpBL, insts.OpBCond, insts.OpBR, insts.OpBLR, insts.OpRET:
+		return t.config.BranchLatency
+
+	case insts.OpLDR:
+		return t.config.LoadLatency
+
+	case insts.OpSTR:
+		return t.config.StoreLatency
+
+	case insts.OpSVC:
+		return t.config.SyscallLatency
+
+	default:
+		return 1
+	}
+}
+
+// GetMinLatency returns the minimum execution latency for variable-latency operations.
+func (t *Table) GetMinLatency(inst *insts.Instruction) uint64 {
+	if inst == nil {
+		return 1
+	}
+
+	// Currently all implemented instructions have fixed latency.
+	// This method is for future multiply/divide support.
+	return t.GetLatency(inst)
+}
+
+// GetMaxLatency returns the maximum execution latency for variable-latency operations.
+func (t *Table) GetMaxLatency(inst *insts.Instruction) uint64 {
+	if inst == nil {
+		return 1
+	}
+
+	// Currently all implemented instructions have fixed latency.
+	return t.GetLatency(inst)
+}
+
+// IsMemoryOp returns true if the instruction accesses memory.
+func (t *Table) IsMemoryOp(inst *insts.Instruction) bool {
+	if inst == nil {
+		return false
+	}
+	return inst.Op == insts.OpLDR || inst.Op == insts.OpSTR
+}
+
+// IsLoadOp returns true if the instruction is a load operation.
+func (t *Table) IsLoadOp(inst *insts.Instruction) bool {
+	if inst == nil {
+		return false
+	}
+	return inst.Op == insts.OpLDR
+}
+
+// IsStoreOp returns true if the instruction is a store operation.
+func (t *Table) IsStoreOp(inst *insts.Instruction) bool {
+	if inst == nil {
+		return false
+	}
+	return inst.Op == insts.OpSTR
+}
+
+// IsBranchOp returns true if the instruction is a branch operation.
+func (t *Table) IsBranchOp(inst *insts.Instruction) bool {
+	if inst == nil {
+		return false
+	}
+	switch inst.Op {
+	case insts.OpB, insts.OpBL, insts.OpBCond, insts.OpBR, insts.OpBLR, insts.OpRET:
+		return true
+	default:
+		return false
+	}
+}
+
+// Config returns the current timing configuration.
+func (t *Table) Config() *TimingConfig {
+	return t.config
+}

--- a/timing/latency/latency_suite_test.go
+++ b/timing/latency/latency_suite_test.go
@@ -1,0 +1,13 @@
+package latency_test
+
+import (
+	"testing"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+)
+
+func TestLatency(t *testing.T) {
+	RegisterFailHandler(Fail)
+	RunSpecs(t, "Latency Suite")
+}

--- a/timing/latency/latency_test.go
+++ b/timing/latency/latency_test.go
@@ -1,0 +1,312 @@
+package latency_test
+
+import (
+	"os"
+	"path/filepath"
+
+	. "github.com/onsi/ginkgo/v2"
+	. "github.com/onsi/gomega"
+	"github.com/sarchlab/m2sim/insts"
+	"github.com/sarchlab/m2sim/timing/latency"
+)
+
+var _ = Describe("Latency", func() {
+	var (
+		table   *latency.Table
+		decoder *insts.Decoder
+	)
+
+	BeforeEach(func() {
+		table = latency.NewTable()
+		decoder = insts.NewDecoder()
+	})
+
+	Describe("Default Timing Values", func() {
+		It("should have correct ALU latency", func() {
+			config := table.Config()
+			Expect(config.ALULatency).To(Equal(uint64(1)))
+		})
+
+		It("should have correct branch latency", func() {
+			config := table.Config()
+			Expect(config.BranchLatency).To(Equal(uint64(1)))
+		})
+
+		It("should have correct load latency", func() {
+			config := table.Config()
+			Expect(config.LoadLatency).To(Equal(uint64(4)))
+		})
+
+		It("should have correct store latency", func() {
+			config := table.Config()
+			Expect(config.StoreLatency).To(Equal(uint64(1)))
+		})
+
+		It("should have correct branch misprediction penalty", func() {
+			config := table.Config()
+			Expect(config.BranchMispredictPenalty).To(Equal(uint64(12)))
+		})
+	})
+
+	Describe("ALU Instruction Latencies", func() {
+		It("should return 1 cycle for ADD immediate", func() {
+			// ADD X0, X1, #42 -> 0x91002820
+			inst := decoder.Decode(0x91002820)
+			Expect(table.GetLatency(inst)).To(Equal(uint64(1)))
+		})
+
+		It("should return 1 cycle for SUB immediate", func() {
+			// SUB X0, X1, #10 -> 0xD1002820
+			inst := decoder.Decode(0xD1002820)
+			Expect(table.GetLatency(inst)).To(Equal(uint64(1)))
+		})
+
+		It("should return 1 cycle for ADD register", func() {
+			// ADD X0, X1, X2 -> 0x8B020020
+			inst := decoder.Decode(0x8B020020)
+			Expect(table.GetLatency(inst)).To(Equal(uint64(1)))
+		})
+
+		It("should return 1 cycle for AND register", func() {
+			// AND X0, X1, X2 -> 0x8A020020
+			inst := decoder.Decode(0x8A020020)
+			Expect(table.GetLatency(inst)).To(Equal(uint64(1)))
+		})
+
+		It("should return 1 cycle for ORR register", func() {
+			// ORR X0, X1, X2 -> 0xAA020020
+			inst := decoder.Decode(0xAA020020)
+			Expect(table.GetLatency(inst)).To(Equal(uint64(1)))
+		})
+
+		It("should return 1 cycle for EOR register", func() {
+			// EOR X0, X1, X2 -> 0xCA020020
+			inst := decoder.Decode(0xCA020020)
+			Expect(table.GetLatency(inst)).To(Equal(uint64(1)))
+		})
+	})
+
+	Describe("Branch Instruction Latencies", func() {
+		It("should return 1 cycle for B", func() {
+			// B #100 -> 0x14000019
+			inst := decoder.Decode(0x14000019)
+			Expect(table.GetLatency(inst)).To(Equal(uint64(1)))
+		})
+
+		It("should return 1 cycle for BL", func() {
+			// BL #100 -> 0x94000019
+			inst := decoder.Decode(0x94000019)
+			Expect(table.GetLatency(inst)).To(Equal(uint64(1)))
+		})
+
+		It("should return 1 cycle for B.EQ", func() {
+			// B.EQ #100 -> 0x54000320
+			inst := decoder.Decode(0x54000320)
+			Expect(table.GetLatency(inst)).To(Equal(uint64(1)))
+		})
+
+		It("should return 1 cycle for BR", func() {
+			// BR X1 -> 0xD61F0020
+			inst := decoder.Decode(0xD61F0020)
+			Expect(table.GetLatency(inst)).To(Equal(uint64(1)))
+		})
+
+		It("should return 1 cycle for RET", func() {
+			// RET -> 0xD65F03C0
+			inst := decoder.Decode(0xD65F03C0)
+			Expect(table.GetLatency(inst)).To(Equal(uint64(1)))
+		})
+	})
+
+	Describe("Memory Instruction Latencies", func() {
+		It("should return 4 cycles for LDR (L1 hit)", func() {
+			// LDR X0, [X1, #8] -> 0xF9400420
+			inst := decoder.Decode(0xF9400420)
+			Expect(table.GetLatency(inst)).To(Equal(uint64(4)))
+		})
+
+		It("should return 1 cycle for STR", func() {
+			// STR X0, [X1, #8] -> 0xF9000420
+			inst := decoder.Decode(0xF9000420)
+			Expect(table.GetLatency(inst)).To(Equal(uint64(1)))
+		})
+	})
+
+	Describe("Instruction Type Detection", func() {
+		It("should detect memory operations", func() {
+			ldr := decoder.Decode(0xF9400420)
+			str := decoder.Decode(0xF9000420)
+			add := decoder.Decode(0x91002820)
+
+			Expect(table.IsMemoryOp(ldr)).To(BeTrue())
+			Expect(table.IsMemoryOp(str)).To(BeTrue())
+			Expect(table.IsMemoryOp(add)).To(BeFalse())
+		})
+
+		It("should detect load operations", func() {
+			ldr := decoder.Decode(0xF9400420)
+			str := decoder.Decode(0xF9000420)
+
+			Expect(table.IsLoadOp(ldr)).To(BeTrue())
+			Expect(table.IsLoadOp(str)).To(BeFalse())
+		})
+
+		It("should detect store operations", func() {
+			ldr := decoder.Decode(0xF9400420)
+			str := decoder.Decode(0xF9000420)
+
+			Expect(table.IsStoreOp(str)).To(BeTrue())
+			Expect(table.IsStoreOp(ldr)).To(BeFalse())
+		})
+
+		It("should detect branch operations", func() {
+			b := decoder.Decode(0x14000019)
+			bl := decoder.Decode(0x94000019)
+			ret := decoder.Decode(0xD65F03C0)
+			add := decoder.Decode(0x91002820)
+
+			Expect(table.IsBranchOp(b)).To(BeTrue())
+			Expect(table.IsBranchOp(bl)).To(BeTrue())
+			Expect(table.IsBranchOp(ret)).To(BeTrue())
+			Expect(table.IsBranchOp(add)).To(BeFalse())
+		})
+	})
+
+	Describe("Nil Instruction Handling", func() {
+		It("should return 1 for nil instruction", func() {
+			Expect(table.GetLatency(nil)).To(Equal(uint64(1)))
+		})
+
+		It("should return false for nil instruction memory check", func() {
+			Expect(table.IsMemoryOp(nil)).To(BeFalse())
+			Expect(table.IsLoadOp(nil)).To(BeFalse())
+			Expect(table.IsStoreOp(nil)).To(BeFalse())
+			Expect(table.IsBranchOp(nil)).To(BeFalse())
+		})
+	})
+
+	Describe("Custom Configuration", func() {
+		It("should use custom config values", func() {
+			config := &latency.TimingConfig{
+				ALULatency:              2,
+				BranchLatency:           3,
+				BranchMispredictPenalty: 20,
+				LoadLatency:             8,
+				StoreLatency:            2,
+				MultiplyLatency:         4,
+				DivideLatencyMin:        12,
+				DivideLatencyMax:        20,
+				SyscallLatency:          1,
+				L1HitLatency:            4,
+				L2HitLatency:            12,
+				L3HitLatency:            30,
+				MemoryLatency:           150,
+			}
+			customTable := latency.NewTableWithConfig(config)
+
+			add := decoder.Decode(0x91002820)
+			ldr := decoder.Decode(0xF9400420)
+			b := decoder.Decode(0x14000019)
+
+			Expect(customTable.GetLatency(add)).To(Equal(uint64(2)))
+			Expect(customTable.GetLatency(ldr)).To(Equal(uint64(8)))
+			Expect(customTable.GetLatency(b)).To(Equal(uint64(3)))
+		})
+	})
+})
+
+var _ = Describe("TimingConfig", func() {
+	Describe("Default Config", func() {
+		It("should create valid default config", func() {
+			config := latency.DefaultTimingConfig()
+			Expect(config.Validate()).To(Succeed())
+		})
+	})
+
+	Describe("Validation", func() {
+		It("should reject zero ALU latency", func() {
+			config := latency.DefaultTimingConfig()
+			config.ALULatency = 0
+			Expect(config.Validate()).To(HaveOccurred())
+		})
+
+		It("should reject zero branch latency", func() {
+			config := latency.DefaultTimingConfig()
+			config.BranchLatency = 0
+			Expect(config.Validate()).To(HaveOccurred())
+		})
+
+		It("should reject zero load latency", func() {
+			config := latency.DefaultTimingConfig()
+			config.LoadLatency = 0
+			Expect(config.Validate()).To(HaveOccurred())
+		})
+
+		It("should reject zero store latency", func() {
+			config := latency.DefaultTimingConfig()
+			config.StoreLatency = 0
+			Expect(config.Validate()).To(HaveOccurred())
+		})
+
+		It("should reject inverted divide latency range", func() {
+			config := latency.DefaultTimingConfig()
+			config.DivideLatencyMin = 20
+			config.DivideLatencyMax = 10
+			Expect(config.Validate()).To(HaveOccurred())
+		})
+	})
+
+	Describe("Clone", func() {
+		It("should create independent copy", func() {
+			original := latency.DefaultTimingConfig()
+			clone := original.Clone()
+
+			clone.ALULatency = 100
+
+			Expect(original.ALULatency).To(Equal(uint64(1)))
+			Expect(clone.ALULatency).To(Equal(uint64(100)))
+		})
+	})
+
+	Describe("File Operations", func() {
+		var tempDir string
+
+		BeforeEach(func() {
+			var err error
+			tempDir, err = os.MkdirTemp("", "latency-test")
+			Expect(err).NotTo(HaveOccurred())
+		})
+
+		AfterEach(func() {
+			os.RemoveAll(tempDir)
+		})
+
+		It("should save and load config", func() {
+			original := latency.DefaultTimingConfig()
+			original.ALULatency = 5
+			original.LoadLatency = 10
+
+			path := filepath.Join(tempDir, "timing.json")
+			Expect(original.SaveConfig(path)).To(Succeed())
+
+			loaded, err := latency.LoadConfig(path)
+			Expect(err).NotTo(HaveOccurred())
+			Expect(loaded.ALULatency).To(Equal(uint64(5)))
+			Expect(loaded.LoadLatency).To(Equal(uint64(10)))
+		})
+
+		It("should return error for non-existent file", func() {
+			_, err := latency.LoadConfig("/nonexistent/path/timing.json")
+			Expect(err).To(HaveOccurred())
+		})
+
+		It("should return error for invalid JSON", func() {
+			path := filepath.Join(tempDir, "invalid.json")
+			err := os.WriteFile(path, []byte("not valid json"), 0644)
+			Expect(err).NotTo(HaveOccurred())
+
+			_, err = latency.LoadConfig(path)
+			Expect(err).To(HaveOccurred())
+		})
+	})
+})


### PR DESCRIPTION
## Summary
Implements issue #25: Add instruction timing model

## Changes
- Created `timing/latency` package with configurable latency table
- Added `TimingConfig` with M2-based default values:
  | Instruction Type | Latency (cycles) |
  |-----------------|------------------|
  | ALU (ADD, SUB, AND, OR, XOR) | 1 |
  | Branch (B, BL, BR, RET) | 1 (+ misprediction penalty) |
  | Load (LDR) | 4 (L1 hit) |
  | Store (STR) | 1 (fire-and-forget) |
  | Multiply (future) | 3-4 |
  | Divide (future) | 10-15 |

- Support JSON config file for timing values (`LoadConfig`/`SaveConfig`)
- Integrated latency table into pipeline:
  - Added `WithLatencyTable` option
  - Track execution stalls for multi-cycle operations
  - Added `ExecStalls` and `MemStalls` statistics

## Testing
- Comprehensive tests for latency lookup by opcode
- Config validation tests
- Config file I/O tests
- Pipeline integration tests verifying:
  - Correct results with latency enabled
  - Execution stall tracking
  - Cycle count increases with longer latencies

## Acceptance Criteria
- [x] Latency table for all implemented instructions
- [x] Pipeline respects latencies (stalls for multi-cycle ops)
- [x] Configuration mechanism for timing values (JSON file)
- [x] Tests verify correct cycle counts

Fixes #25