### PR TITLE
[Frank] Document timing model parameters

### DIFF
--- a/CALIBRATION.md
+++ b/CALIBRATION.md
@@ -1,0 +1,210 @@
+# M2Sim Calibration Reference
+
+This document catalogs all timing parameters in M2Sim's timing model. Use this as a reference for calibration against real Apple M2 hardware.
+
+## Overview
+
+M2Sim models a 5-stage pipeline with:
+- Fetch (IF) → Decode (ID) → Execute (EX) → Memory (MEM) → Writeback (WB)
+- L1 instruction and data caches
+- Configurable instruction latencies
+- Hazard detection with forwarding and stalls
+
+---
+
+## Instruction Latencies
+
+**Source:** `timing/latency/config.go`
+
+| Parameter | Default Value | Description | Tunable |
+|-----------|---------------|-------------|---------|
+| `ALULatency` | 1 cycle | Basic ALU ops (ADD, SUB, AND, OR, XOR) | ✅ Yes |
+| `BranchLatency` | 1 cycle | Base branch execution (no misprediction) | ✅ Yes |
+| `BranchMispredictPenalty` | 12 cycles | Additional penalty on misprediction | ✅ Yes |
+| `LoadLatency` | 4 cycles | Load assuming L1 hit | ✅ Yes |
+| `StoreLatency` | 1 cycle | Store to LSQ (fire-and-forget) | ✅ Yes |
+| `MultiplyLatency` | 3 cycles | Integer multiply (future) | ✅ Yes |
+| `DivideLatencyMin` | 10 cycles | Integer divide minimum (future) | ✅ Yes |
+| `DivideLatencyMax` | 15 cycles | Integer divide maximum (future) | ✅ Yes |
+| `SyscallLatency` | 1 cycle | System call instruction | ✅ Yes |
+
+**How to configure:** Pass a `TimingConfig` to `latency.NewTableWithConfig()`, or load from JSON with `latency.LoadConfig(path)`.
+
+---
+
+## L1 Instruction Cache
+
+**Source:** `timing/cache/cache.go` → `DefaultL1IConfig()`
+
+| Parameter | Default Value | Apple M2 Reference | Tunable |
+|-----------|---------------|-------------------|---------|
+| `Size` | 192 KB | 192 KB (P-core), 128 KB (E-core) | ✅ Yes |
+| `Associativity` | 6-way | 6-way (P-core), 4-way (E-core) | ✅ Yes |
+| `BlockSize` | 64 bytes | 64 bytes | ✅ Yes |
+| `HitLatency` | 1 cycle | ~1-2 cycles | ✅ Yes |
+| `MissLatency` | 12 cycles | ~12 cycles (to L2) | ✅ Yes |
+
+---
+
+## L1 Data Cache
+
+**Source:** `timing/cache/cache.go` → `DefaultL1DConfig()`
+
+| Parameter | Default Value | Apple M2 Reference | Tunable |
+|-----------|---------------|-------------------|---------|
+| `Size` | 128 KB | 128 KB (P-core), 64 KB (E-core) | ✅ Yes |
+| `Associativity` | 8-way | 8-way (P-core), 4-way (E-core) | ✅ Yes |
+| `BlockSize` | 64 bytes | 64 bytes | ✅ Yes |
+| `HitLatency` | 1 cycle | ~4 cycles | ⚠️ Review |
+| `MissLatency` | 12 cycles | ~12 cycles (to L2) | ✅ Yes |
+
+**Note:** L1D `HitLatency` is 1 cycle in cache config, but `LoadLatency` (4 cycles) in the latency table represents total load-to-use latency. These interact—need clarification on how they combine.
+
+---
+
+## L2 Cache (Unified)
+
+**Source:** `timing/cache/cache.go` → `DefaultL2Config()`
+
+| Parameter | Default Value | Apple M2 Reference | Tunable |
+|-----------|---------------|-------------------|---------|
+| `Size` | 16 MB | 16 MB (shared per cluster) | ✅ Yes |
+| `Associativity` | 16-way | 16-way (estimated) | ✅ Yes |
+| `BlockSize` | 128 bytes | 128 bytes | ✅ Yes |
+| `HitLatency` | 12 cycles | ~12-14 cycles | ✅ Yes |
+| `MissLatency` | 200 cycles | ~150-200 cycles (to DRAM) | ✅ Yes |
+
+**Note:** L2 cache is implemented but not yet integrated into the default pipeline configuration.
+
+---
+
+## Memory Latencies
+
+**Source:** `timing/latency/config.go`
+
+| Parameter | Default Value | Apple M2 Reference | Tunable |
+|-----------|---------------|-------------------|---------|
+| `L1HitLatency` | 4 cycles | ~4 cycles | ✅ Yes |
+| `L2HitLatency` | 12 cycles | ~12-14 cycles | ✅ Yes |
+| `L3HitLatency` | 30 cycles | N/A (M2 has SLC, not L3) | ⚠️ Review |
+| `MemoryLatency` | 150 cycles | ~100-200 cycles (LPDDR5) | ✅ Yes |
+
+**Note:** Apple M2 uses System-Level Cache (SLC) instead of traditional L3. The `L3HitLatency` parameter may need renaming or removal.
+
+---
+
+## Pipeline Structure
+
+**Source:** `timing/pipeline/pipeline.go`
+
+| Component | Description | Fixed/Tunable |
+|-----------|-------------|---------------|
+| 5-stage pipeline | IF → ID → EX → MEM → WB | 🔒 Fixed |
+| Pipeline registers | IFID, IDEX, EXMEM, MEMWB | 🔒 Fixed |
+| Hazard detection | Full forwarding + load-use stalls | 🔒 Fixed |
+| Branch handling | Always-not-taken prediction | ⚠️ Needs work |
+
+**Note:** Current branch predictor is trivial (always not-taken). Real M2 has sophisticated branch prediction. This is a significant accuracy gap.
+
+---
+
+## Hardcoded Values
+
+These values are embedded in code and require source changes:
+
+| Location | Value | Description |
+|----------|-------|-------------|
+| `pipeline.go` | 5 stages | Pipeline depth |
+| `pipeline.go` | 1 cycle/stage | Stage latency (ideal) |
+| Tests | 6 cycles | Expected instruction completion time |
+| Tests | 10 cycles | Cache miss completion time |
+
+---
+
+## Configuration Methods
+
+### 1. Programmatic (Go API)
+
+```go
+// Custom latency table
+config := &latency.TimingConfig{
+    ALULatency:              1,
+    LoadLatency:             4,
+    BranchMispredictPenalty: 12,
+    // ...
+}
+table := latency.NewTableWithConfig(config)
+pipe := pipeline.NewPipeline(regFile, mem, pipeline.WithLatencyTable(table))
+
+// Custom cache configuration
+icacheConfig := cache.Config{
+    Size:          192 * 1024,
+    Associativity: 6,
+    BlockSize:     64,
+    HitLatency:    1,
+    MissLatency:   12,
+}
+pipe := pipeline.NewPipeline(regFile, mem, pipeline.WithICache(icacheConfig))
+```
+
+### 2. JSON Configuration File
+
+```json
+{
+    "alu_latency": 1,
+    "branch_latency": 1,
+    "branch_mispredict_penalty": 12,
+    "load_latency": 4,
+    "store_latency": 1,
+    "multiply_latency": 3,
+    "divide_latency_min": 10,
+    "divide_latency_max": 15,
+    "syscall_latency": 1,
+    "l1_hit_latency": 4,
+    "l2_hit_latency": 12,
+    "l3_hit_latency": 30,
+    "memory_latency": 150
+}
+```
+
+Load with: `config, err := latency.LoadConfig("timing.json")`
+
+---
+
+## Known Calibration Gaps
+
+### High Priority
+1. **Branch prediction** - Currently always-not-taken; M2 has advanced predictors
+2. **L1D hit latency discrepancy** - Cache config says 1 cycle, latency table says 4 cycles
+3. **Out-of-order execution** - M2 is OoO; we model in-order only
+
+### Medium Priority
+4. **L3/SLC naming** - Parameter exists but M2 doesn't have traditional L3
+5. **Store buffer** - Not modeled; stores appear instant
+6. **Memory disambiguation** - Not modeled
+
+### Low Priority
+7. **E-core vs P-core** - Currently P-core defaults only
+8. **Multi-core** - Not yet implemented
+9. **SMT** - Not applicable to M2
+
+---
+
+## Calibration Workflow
+
+1. **Baseline measurement**: Run benchmarks on real M2, collect cycles/IPC
+2. **Simulation**: Run same benchmarks in M2Sim
+3. **Compare**: Identify largest discrepancies
+4. **Tune**: Adjust parameters, prioritizing high-impact ones
+5. **Iterate**: Re-run and refine
+
+Recommended benchmarks:
+- Simple loops (ALU-bound)
+- Memory traversal (cache-bound)
+- Branch-heavy code (predictor-bound)
+- Mixed workloads
+
+---
+
+*Document generated by Frank for M2Sim calibration phase.*
+*Last updated: Issue #74*


### PR DESCRIPTION
## Summary
Comprehensive documentation of all timing parameters in M2Sim for the calibration phase.

## Changes
- Created CALIBRATION.md with:
  - Instruction latencies (ALU, branch, load, store, multiply, divide)
  - L1 I-cache configuration (192KB, 6-way, 64B lines)
  - L1 D-cache configuration (128KB, 8-way, 64B lines)
  - L2 cache configuration (16MB, 16-way, 128B lines)
  - Memory latency hierarchy
  - Pipeline structure overview
  - Known calibration gaps and priorities
  - Configuration methods (Go API and JSON)
  - Recommended calibration workflow

## Key Findings
- **L1D hit latency discrepancy**: Cache config says 1 cycle, latency table says 4 cycles - needs clarification
- **Branch prediction**: Currently always-not-taken, significant accuracy gap vs real M2
- **L3/SLC naming**: Parameter exists but M2 uses SLC, not traditional L3

Closes #74