### PR TITLE
[Bob] Create native M2 calibration test programs

### DIFF
--- a/benchmarks/native/.gitignore
+++ b/benchmarks/native/.gitignore
@@ -1,0 +1,12 @@
+# Build artifacts
+*.o
+arithmetic_sequential
+dependency_chain
+memory_sequential
+function_calls
+branch_taken
+mixed_operations
+
+# Trace files
+*.trace
+*.trace/

--- a/benchmarks/native/Makefile
+++ b/benchmarks/native/Makefile
@@ -1,0 +1,81 @@
+# Makefile for M2Sim Native Calibration Benchmarks
+# Compiles ARM64 assembly benchmarks for macOS
+
+# Detect architecture
+ARCH := $(shell uname -m)
+
+# Compiler settings
+AS = as
+LD = ld
+
+# macOS-specific linker flags
+LDFLAGS = -lSystem -L$(shell xcrun --show-sdk-path)/usr/lib -syslibroot $(shell xcrun --show-sdk-path) -e _main
+
+# Assembly sources
+SRCS = arithmetic_sequential.s \
+       dependency_chain.s \
+       memory_sequential.s \
+       function_calls.s \
+       branch_taken.s \
+       mixed_operations.s
+
+# Output binaries
+BINS = $(SRCS:.s=)
+
+# Object files
+OBJS = $(SRCS:.s=.o)
+
+.PHONY: all clean run check
+
+all: check_arch $(BINS)
+
+check_arch:
+ifneq ($(ARCH),arm64)
+	$(error This Makefile requires ARM64/Apple Silicon. Current arch: $(ARCH))
+endif
+
+# Pattern rule: .s -> .o
+%.o: %.s
+	$(AS) -o $@ $<
+
+# Pattern rule: .o -> binary
+%: %.o
+	$(LD) $(LDFLAGS) -o $@ $<
+
+# Build all binaries
+$(BINS): %: %.o
+
+clean:
+	rm -f $(OBJS) $(BINS)
+
+# Run all benchmarks and verify exit codes
+run: all
+	@echo "Running native calibration benchmarks..."
+	@echo ""
+	@for bin in $(BINS); do \
+		printf "%-25s: " "$$bin"; \
+		./$$bin; \
+		echo "exit=$$?"; \
+	done
+
+# Verify expected exit codes match
+verify: all
+	@echo "Verifying benchmark exit codes..."
+	@failed=0; \
+	./arithmetic_sequential; test $$? -eq 4 || { echo "FAIL: arithmetic_sequential (expected 4)"; failed=1; }; \
+	./dependency_chain; test $$? -eq 20 || { echo "FAIL: dependency_chain (expected 20)"; failed=1; }; \
+	./memory_sequential; test $$? -eq 42 || { echo "FAIL: memory_sequential (expected 42)"; failed=1; }; \
+	./function_calls; test $$? -eq 5 || { echo "FAIL: function_calls (expected 5)"; failed=1; }; \
+	./branch_taken; test $$? -eq 5 || { echo "FAIL: branch_taken (expected 5)"; failed=1; }; \
+	./mixed_operations; test $$? -eq 100 || { echo "FAIL: mixed_operations (expected 100)"; failed=1; }; \
+	if [ $$failed -eq 0 ]; then echo "All benchmarks verified!"; else exit 1; fi
+
+# Time a single benchmark with /usr/bin/time
+time-%: %
+	@echo "Timing $<..."
+	/usr/bin/time -l ./$<
+
+# Run benchmark N times for statistical sampling
+bench-%: %
+	@echo "Running $< 1000 times..."
+	@for i in $$(seq 1 1000); do ./$<; done

--- a/benchmarks/native/README.md
+++ b/benchmarks/native/README.md
@@ -1,0 +1,175 @@
+# Native M2 Calibration Benchmarks
+
+Native ARM64 assembly programs for calibrating M2Sim's timing model against real Apple M2 hardware.
+
+## Overview
+
+These benchmarks are 1:1 translations of the microbenchmarks in `benchmarks/microbenchmarks.go`. They allow direct comparison between simulator and real hardware performance.
+
+| Benchmark | Description | Expected Exit Code |
+|-----------|-------------|-------------------|
+| `arithmetic_sequential` | 20 independent ADDs (ALU throughput) | 4 |
+| `dependency_chain` | 20 dependent ADDs (forwarding latency) | 20 |
+| `memory_sequential` | 10 store/load pairs (cache performance) | 42 |
+| `function_calls` | 5 BL/RET pairs (call overhead) | 5 |
+| `branch_taken` | 5 unconditional branches | 5 |
+| `mixed_operations` | Mix of ALU, memory, calls | 100 |
+
+## Requirements
+
+- Apple Silicon Mac (M1/M2/M3)
+- Xcode Command Line Tools (`xcode-select --install`)
+
+## Building
+
+```bash
+cd benchmarks/native
+make
+```
+
+## Running
+
+```bash
+# Run all benchmarks (shows exit codes)
+make run
+
+# Verify exit codes match expectations
+make verify
+```
+
+## Collecting Performance Data
+
+### Method 1: /usr/bin/time (Basic)
+
+```bash
+/usr/bin/time -l ./dependency_chain
+```
+
+Shows wall clock time, user/system time, and memory stats.
+
+### Method 2: Instruments (Recommended)
+
+Apple's Instruments provides access to CPU performance counters including cycle counts.
+
+#### Using Xcode Instruments GUI:
+
+1. Open Instruments: `open -a Instruments`
+2. Choose "Time Profiler" or "CPU Counters" template
+3. File → Record Options → Set target to your benchmark binary
+4. Add PMC events: Cycles, Instructions, Branch Mispredictions, L1D Cache Misses
+5. Record and analyze
+
+#### Using xctrace CLI:
+
+```bash
+# Record CPU counters for a benchmark
+xctrace record --template 'CPU Counters' --output trace.trace --launch -- ./dependency_chain
+
+# Export to readable format
+xctrace export --input trace.trace --output trace.xml
+```
+
+### Method 3: powermetrics (System-wide)
+
+```bash
+# Must run as root - shows system-wide CPU counters
+sudo powermetrics --samplers cpu_power -i 100
+```
+
+### Method 4: Sample Script for Batch Collection
+
+```bash
+#!/bin/bash
+# collect_stats.sh - Run benchmark N times and collect stats
+
+BENCHMARK=$1
+ITERATIONS=${2:-100}
+
+echo "Benchmark: $BENCHMARK"
+echo "Iterations: $ITERATIONS"
+echo ""
+
+total_ns=0
+for i in $(seq 1 $ITERATIONS); do
+    # Use gdate for nanosecond precision (install: brew install coreutils)
+    start=$(gdate +%s%N)
+    ./$BENCHMARK
+    end=$(gdate +%s%N)
+    elapsed=$((end - start))
+    total_ns=$((total_ns + elapsed))
+done
+
+avg_ns=$((total_ns / ITERATIONS))
+avg_us=$((avg_ns / 1000))
+
+echo "Average time: ${avg_us} microseconds"
+```
+
+## Interpreting Results
+
+### What to Compare
+
+1. **CPI (Cycles Per Instruction)**: Key metric for timing model accuracy
+   - Run simulator: `go run ./cmd/m2sim benchmark --json`
+   - Run native: Collect cycles via Instruments
+   - Compare CPI for each benchmark
+
+2. **Relative Performance**: Which benchmarks are faster/slower?
+   - If simulator shows dependency_chain 2x slower than arithmetic_sequential
+   - Real hardware should show similar ratio
+
+### Expected M2 Characteristics
+
+Based on published data and testing:
+
+| Characteristic | Expected Value |
+|---------------|----------------|
+| P-core frequency | 3.5 GHz |
+| ALU latency (independent) | ~1 cycle |
+| ALU latency (dependent) | ~1 cycle with forwarding |
+| L1D hit latency | ~4 cycles |
+| Branch misprediction penalty | ~12-14 cycles |
+| BL/RET overhead | ~1-2 cycles (predicted) |
+
+## Comparing with Simulator
+
+Run the simulator benchmarks:
+
+```bash
+cd ../..
+go run ./cmd/m2sim benchmark --json > sim_results.json
+```
+
+Then compare CPI values:
+
+```bash
+# Example comparison workflow (pseudo-code)
+# sim_cpi = sim_results[benchmark]["cycles"] / sim_results[benchmark]["instructions"]  
+# hw_cpi = hardware_cycles / hardware_instructions
+# error = abs(sim_cpi - hw_cpi) / hw_cpi * 100
+```
+
+## Troubleshooting
+
+### "This Makefile requires ARM64"
+You're on an Intel Mac. These benchmarks require Apple Silicon.
+
+### Permission denied for Instruments
+Grant Terminal.app "Full Disk Access" in System Preferences → Privacy & Security.
+
+### xctrace not found
+Install Xcode Command Line Tools: `xcode-select --install`
+
+## Files
+
+```
+benchmarks/native/
+├── Makefile                    # Build system
+├── README.md                   # This file
+├── arithmetic_sequential.s     # ALU throughput test
+├── dependency_chain.s          # RAW hazard test  
+├── memory_sequential.s         # Cache/memory test
+├── function_calls.s            # BL/RET overhead test
+├── branch_taken.s              # Branch overhead test
+└── mixed_operations.s          # Realistic workload test
+```

--- a/benchmarks/native/arithmetic_sequential.s
+++ b/benchmarks/native/arithmetic_sequential.s
@@ -1,0 +1,47 @@
+// arithmetic_sequential.s - 20 independent ADD operations
+// Tests ALU throughput with independent operations
+// Matches: benchmarks/microbenchmarks.go arithmeticSequential()
+//
+// Expected: X0 = 4 at exit (X0 incremented 4 times total across rounds)
+
+.global _main
+.align 4
+
+_main:
+    // Initialize
+    mov x0, #0
+    mov x1, #0
+    mov x2, #0
+    mov x3, #0
+    mov x4, #0
+
+    // --- Timing region starts here ---
+    // 20 independent ADDs to different registers
+    add x0, x0, #1
+    add x1, x1, #1
+    add x2, x2, #1
+    add x3, x3, #1
+    add x4, x4, #1
+
+    add x0, x0, #1
+    add x1, x1, #1
+    add x2, x2, #1
+    add x3, x3, #1
+    add x4, x4, #1
+
+    add x0, x0, #1
+    add x1, x1, #1
+    add x2, x2, #1
+    add x3, x3, #1
+    add x4, x4, #1
+
+    add x0, x0, #1
+    add x1, x1, #1
+    add x2, x2, #1
+    add x3, x3, #1
+    add x4, x4, #1
+    // --- Timing region ends here ---
+
+    // Exit syscall (x0 already has return value = 4)
+    mov x16, #1         // SYS_exit
+    svc #0x80

--- a/benchmarks/native/branch_taken.s
+++ b/benchmarks/native/branch_taken.s
@@ -1,0 +1,48 @@
+// branch_taken.s - 5 unconditional branches
+// Tests unconditional branch overhead
+// Matches: benchmarks/microbenchmarks.go branchTaken()
+//
+// Expected: X0 = 5 at exit
+
+.global _main
+.align 4
+
+_main:
+    // Initialize
+    mov x0, #0
+
+    // --- Timing region starts here ---
+    // Branch 1: jump over skipped instruction
+    b .L1_land
+    add x1, x1, #99     // skipped
+.L1_land:
+    add x0, x0, #1      // X0 = 1
+
+    // Branch 2
+    b .L2_land
+    add x1, x1, #99     // skipped
+.L2_land:
+    add x0, x0, #1      // X0 = 2
+
+    // Branch 3
+    b .L3_land
+    add x1, x1, #99     // skipped
+.L3_land:
+    add x0, x0, #1      // X0 = 3
+
+    // Branch 4
+    b .L4_land
+    add x1, x1, #99     // skipped
+.L4_land:
+    add x0, x0, #1      // X0 = 4
+
+    // Branch 5
+    b .L5_land
+    add x1, x1, #99     // skipped
+.L5_land:
+    add x0, x0, #1      // X0 = 5
+    // --- Timing region ends here ---
+
+    // Exit syscall (x0 = 5)
+    mov x16, #1         // SYS_exit
+    svc #0x80

--- a/benchmarks/native/dependency_chain.s
+++ b/benchmarks/native/dependency_chain.s
@@ -1,0 +1,43 @@
+// dependency_chain.s - 20 dependent ADD operations
+// Tests instruction latency with RAW hazards (data dependencies)
+// Matches: benchmarks/microbenchmarks.go dependencyChain()
+//
+// Expected: X0 = 20 at exit
+
+.global _main
+.align 4
+
+_main:
+    // Initialize
+    mov x0, #0
+
+    // --- Timing region starts here ---
+    // 20 dependent ADDs (each depends on previous result)
+    add x0, x0, #1
+    add x0, x0, #1
+    add x0, x0, #1
+    add x0, x0, #1
+    add x0, x0, #1
+
+    add x0, x0, #1
+    add x0, x0, #1
+    add x0, x0, #1
+    add x0, x0, #1
+    add x0, x0, #1
+
+    add x0, x0, #1
+    add x0, x0, #1
+    add x0, x0, #1
+    add x0, x0, #1
+    add x0, x0, #1
+
+    add x0, x0, #1
+    add x0, x0, #1
+    add x0, x0, #1
+    add x0, x0, #1
+    add x0, x0, #1
+    // --- Timing region ends here ---
+
+    // Exit syscall (x0 = 20)
+    mov x16, #1         // SYS_exit
+    svc #0x80

--- a/benchmarks/native/function_calls.s
+++ b/benchmarks/native/function_calls.s
@@ -1,0 +1,37 @@
+// function_calls.s - 5 function calls (BL + RET pairs)
+// Tests call/return overhead
+// Matches: benchmarks/microbenchmarks.go functionCalls()
+//
+// Expected: X0 = 5 at exit
+
+.global _main
+.align 4
+
+_main:
+    // Setup frame
+    stp x29, x30, [sp, #-16]!
+    mov x29, sp
+
+    // Initialize
+    mov x0, #0
+
+    // --- Timing region starts here ---
+    // 5 function calls to add_one
+    bl _add_one
+    bl _add_one
+    bl _add_one
+    bl _add_one
+    bl _add_one
+    // --- Timing region ends here ---
+
+    // Restore frame
+    ldp x29, x30, [sp], #16
+
+    // Exit syscall (x0 = 5)
+    mov x16, #1         // SYS_exit
+    svc #0x80
+
+// add_one: increments x0 by 1
+_add_one:
+    add x0, x0, #1
+    ret

--- a/benchmarks/native/memory_sequential.s
+++ b/benchmarks/native/memory_sequential.s
@@ -1,0 +1,56 @@
+// memory_sequential.s - 10 store/load pairs to sequential addresses
+// Tests cache/memory performance
+// Matches: benchmarks/microbenchmarks.go memorySequential()
+//
+// Expected: X0 = 42 at exit (value stored and loaded back)
+
+.global _main
+.align 4
+
+_main:
+    // Allocate stack space for buffer (80 bytes = 10 * 8 bytes)
+    sub sp, sp, #80
+
+    // Initialize
+    mov x0, #42         // Value to store/load
+    mov x1, sp          // Base address (stack buffer)
+
+    // --- Timing region starts here ---
+    // 10 store/load pairs at sequential 8-byte offsets
+    str x0, [x1, #0]
+    ldr x0, [x1, #0]
+
+    str x0, [x1, #8]
+    ldr x0, [x1, #8]
+
+    str x0, [x1, #16]
+    ldr x0, [x1, #16]
+
+    str x0, [x1, #24]
+    ldr x0, [x1, #24]
+
+    str x0, [x1, #32]
+    ldr x0, [x1, #32]
+
+    str x0, [x1, #40]
+    ldr x0, [x1, #40]
+
+    str x0, [x1, #48]
+    ldr x0, [x1, #48]
+
+    str x0, [x1, #56]
+    ldr x0, [x1, #56]
+
+    str x0, [x1, #64]
+    ldr x0, [x1, #64]
+
+    str x0, [x1, #72]
+    ldr x0, [x1, #72]
+    // --- Timing region ends here ---
+
+    // Cleanup stack
+    add sp, sp, #80
+
+    // Exit syscall (x0 = 42)
+    mov x16, #1         // SYS_exit
+    svc #0x80

--- a/benchmarks/native/mixed_operations.s
+++ b/benchmarks/native/mixed_operations.s
@@ -1,0 +1,59 @@
+// mixed_operations.s - Mix of ADD, STR/LDR, and BL
+// Tests realistic workload characteristics
+// Matches: benchmarks/microbenchmarks.go mixedOperations()
+//
+// Expected: X0 = 100 at exit
+// Calculation:
+//   iter1: X0=0, X2=10, store/load X3=10, X0=10, call add_five → X0=15
+//   iter2: X0=15, X2=25, store/load X3=25, X0=40, call add_five → X0=45
+//   iter3: X0=45, X2=55, store/load X3=55, X0=100
+
+.global _main
+.align 4
+
+_main:
+    // Setup frame
+    stp x29, x30, [sp, #-16]!
+    mov x29, sp
+
+    // Allocate buffer (24 bytes = 3 * 8 bytes)
+    sub sp, sp, #32     // Keep 16-byte aligned
+
+    // Initialize
+    mov x0, #0          // X0 = sum
+    mov x1, sp          // X1 = buffer address
+
+    // --- Timing region starts here ---
+    // Iteration 1: compute, store, load, call
+    add x2, x0, #10     // X2 = X0 + 10 = 10
+    str x2, [x1, #0]    // [X1] = X2
+    ldr x3, [x1, #0]    // X3 = [X1] = 10
+    add x0, x0, x3      // X0 += X3 → X0 = 10
+    bl _add_five        // X0 += 5 → X0 = 15
+
+    // Iteration 2
+    add x2, x0, #10     // X2 = 25
+    str x2, [x1, #8]
+    ldr x3, [x1, #8]    // X3 = 25
+    add x0, x0, x3      // X0 = 40
+    bl _add_five        // X0 = 45
+
+    // Iteration 3
+    add x2, x0, #10     // X2 = 55
+    str x2, [x1, #16]
+    ldr x3, [x1, #16]   // X3 = 55
+    add x0, x0, x3      // X0 = 100
+    // --- Timing region ends here ---
+
+    // Cleanup
+    add sp, sp, #32
+    ldp x29, x30, [sp], #16
+
+    // Exit syscall (x0 = 100)
+    mov x16, #1         // SYS_exit
+    svc #0x80
+
+// add_five: increments x0 by 5
+_add_five:
+    add x0, x0, #5
+    ret


### PR DESCRIPTION
Closes #79

## Summary

Native ARM64 assembly versions of all 6 microbenchmarks for real M2 hardware comparison:

| Benchmark | Description | Expected Exit Code |
|-----------|-------------|-------------------|
| `arithmetic_sequential` | 20 independent ADDs (ALU throughput) | 4 |
| `dependency_chain` | 20 dependent ADDs (forwarding latency) | 20 |
| `memory_sequential` | 10 store/load pairs (cache performance) | 42 |
| `function_calls` | 5 BL/RET pairs (call overhead) | 5 |
| `branch_taken` | 5 unconditional branches | 5 |
| `mixed_operations` | Mix of ALU, memory, calls | 100 |

## Changes

- `benchmarks/native/*.s` - ARM64 assembly matching each Go microbenchmark
- `benchmarks/native/Makefile` - Build system for macOS ARM64
- `benchmarks/native/README.md` - Instructions for running and collecting cycle counts
- `benchmarks/native/.gitignore` - Exclude build artifacts

## Verification

All benchmarks compile and produce the expected exit codes matching the simulator:

```
$ make verify
Verifying benchmark exit codes...
All benchmarks verified!
```

## How to Use

1. Build: `cd benchmarks/native && make`
2. Verify: `make verify`
3. Collect cycles: See README.md for Instruments/xctrace instructions