### PR TITLE
[Cathy] Add validation test plan for Issue #97

### DIFF
--- a/docs/validation-test-plan.md
+++ b/docs/validation-test-plan.md
@@ -1,169 +1,337 @@
-# Validation Test Plan for M2Sim Accuracy
+# M2Sim Validation Test Plan
 
+**Issue:** #97 (Accuracy analysis and reporting)  
+**Target:** <2% average error across benchmarks  
 **Author:** Cathy (QA Agent)  
-**Date:** 2026-02-03  
-**Status:** DRAFT  
+**Date:** 2026-02-03
 
-## Objective
+## Overview
 
-Create automated validation tests to verify M2Sim achieves <2% error against real Apple M2 hardware measurements.
+This document outlines the methodology for validating M2Sim simulator accuracy against real M2 hardware, including data collection procedures, statistical analysis methods, and CI integration for ongoing accuracy monitoring.
 
-## Dependencies
+## 1. Data Collection Strategy
 
-- ✅ Issue #95 (Bob's benchmark harness) - provides simulator timing data
-- ✅ Issue #96 (Cathy's M2 baseline) - provides real hardware measurements
-- ⏳ Issue #97 (accuracy analysis) - this plan implements
+### 1.1 Hardware Measurements (Ground Truth)
 
-## Test Categories
+**Challenge:** Process startup overhead (~18ms) dominates measurements for micro-benchmarks.
 
-### 1. Core Accuracy Tests (Go tests in `benchmarks/`)
+**Solution: Apple Instruments with CPU Counters**
 
-#### Test: `TestAccuracy_ArithmeticThroughput`
-**Purpose:** Verify simulator CPI matches real M2 for independent ALU operations.
+```bash
+# Collect hardware performance counters (no overhead interference)
+xcrun xctrace record --template "CPU Counters" \
+  --output benchmark.trace \
+  --launch ./bin/benchmark_program
 
-```go
-// Compare simulator arithmetic_sequential vs baseline arithmetic
-// Baseline: CPI = 0.268 (M2 can issue ~4 ADDs per cycle)
-// Target: |sim_cpi - 0.268| / 0.268 < 2%
+# Extract cycle counts from trace
+xcrun xctrace export --input benchmark.trace --output cycles.json
 ```
 
-**Current gap:** Simulator shows CPI ~1.2 for arithmetic_sequential vs M2's 0.268. This is expected - simulator doesn't model superscalar issue width.
+**Metrics to Collect:**
+- `FIXED_CYCLES` - Total CPU cycles
+- `INST_RETIRED` - Instructions retired
+- `BRANCH_MISPRED` - Branch mispredictions (for branch predictor validation)
+- `L1D_CACHE_MISS` - L1 data cache misses (for cache validation)
 
-**Action:** Document as known limitation or update timing model.
+### 1.2 Simulator Measurements
 
-#### Test: `TestAccuracy_DependencyChain`
-**Purpose:** Verify simulator CPI matches real M2 for RAW hazard chains.
+```bash
+# Run benchmark harness with JSON output
+./bin/m2sim benchmark -format=json -o simulated.json
 
-```go
-// Compare simulator dependency_chain vs baseline dependency
-// Baseline: CPI = 1.009 (one add per cycle due to data dependency)
-// Target: |sim_cpi - 1.009| / 1.009 < 2%
+# Key metrics captured:
+# - cycles: Simulated cycle count
+# - instructions: Instruction count
+# - cpi: Cycles per instruction
 ```
 
-**Current status:** Simulator shows CPI ~2.2 vs M2's 1.009. May indicate forwarding path not modeled accurately.
+### 1.3 Benchmark Requirements
 
-#### Test: `TestAccuracy_BranchPrediction`
-**Purpose:** Verify simulator branch overhead matches real M2.
+To minimize measurement noise and enable accurate comparison:
 
-```go
-// Compare simulator branch_taken vs baseline branch
-// Baseline: CPI = 1.19 (well-predicted branches minimal penalty)
-// Target: |sim_cpi - 1.19| / 1.19 < 2%
+| Requirement | Minimum | Rationale |
+|-------------|---------|-----------|
+| Instruction count | 1M+ | Amortize measurement overhead |
+| Determinism | 100% | Same input → same output |
+| No I/O | Required | Avoid system call variance |
+| No heap allocation | Preferred | Avoid allocator variance |
+
+**Recommended Benchmark Extensions:**
+- `loop_simulation_1M` - 1 million iterations
+- `matrix_operations_1K` - 1000 matrix multiplications
+- `dependency_chain_100K` - 100K dependent operations
+
+## 2. Error Calculation Methodology
+
+### 2.1 Per-Benchmark Error
+
+For each benchmark `b`:
+
+```
+error_b = |simulated_cycles_b - measured_cycles_b| / measured_cycles_b × 100%
 ```
 
-**Current status:** Simulator shows CPI ~2.9 vs M2's 1.19. Branch prediction model needs calibration.
+**Signed Error (for bias detection):**
 
-### 2. Automated Comparison Tool
+```
+signed_error_b = (simulated_cycles_b - measured_cycles_b) / measured_cycles_b × 100%
+```
 
-Create `benchmarks/accuracy_test.go`:
+Positive = simulator over-predicts; Negative = simulator under-predicts.
 
-```go
-func TestAccuracyAgainstBaseline(t *testing.T) {
-    // 1. Load baseline from benchmarks/native/m2_baseline.json
-    baseline := loadBaseline("native/m2_baseline.json")
-    
-    // 2. Run simulator benchmarks (without caches to isolate core timing)
-    config := DefaultConfig()
-    config.EnableICache = false
-    config.EnableDCache = false
-    harness := NewHarness(config)
-    harness.AddBenchmarks(GetMicrobenchmarks())
-    results := harness.RunAll()
-    
-    // 3. Map simulator benchmarks to baselines
-    mapping := map[string]string{
-        "arithmetic_sequential": "arithmetic",
-        "dependency_chain":      "dependency",
-        "branch_taken":          "branch",
+### 2.2 Aggregate Error Metrics
+
+**Mean Absolute Percentage Error (MAPE):**
+
+```
+MAPE = (1/n) × Σ |error_b|
+```
+
+This is our primary accuracy metric. Target: MAPE < 2%.
+
+**Root Mean Square Error (RMSE):**
+
+```
+RMSE = sqrt((1/n) × Σ (error_b)²)
+```
+
+Penalizes large outliers more heavily.
+
+**Weighted MAPE (by instruction count):**
+
+```
+WMAPE = Σ(instructions_b × |error_b|) / Σ(instructions_b)
+```
+
+Gives more weight to longer-running benchmarks.
+
+### 2.3 Statistical Confidence
+
+For each benchmark, run N=10 iterations and calculate:
+
+- Mean cycle count
+- Standard deviation
+- 95% confidence interval: `mean ± 1.96 × (std / √n)`
+
+Only count error as significant if simulator prediction falls outside hardware CI.
+
+## 3. Report Generation
+
+### 3.1 Accuracy Report Format
+
+```json
+{
+  "report_date": "2026-02-03T16:00:00Z",
+  "simulator_version": "v0.6.0",
+  "hardware": "Apple M2",
+  "summary": {
+    "mape": 1.85,
+    "rmse": 2.12,
+    "wmape": 1.72,
+    "pass": true,
+    "target": 2.0
+  },
+  "benchmarks": [
+    {
+      "name": "loop_simulation_1M",
+      "simulated_cycles": 1020000,
+      "measured_cycles": 1000000,
+      "measured_stddev": 5000,
+      "error_pct": 2.0,
+      "signed_error_pct": 2.0,
+      "pass": true
     }
-    
-    // 4. Calculate and report errors
-    for simName, baselineName := range mapping {
-        simResult := findResult(results, simName)
-        baselineData := findBaseline(baseline, baselineName)
-        
-        error := math.Abs(simResult.CPI - baselineData.CPI) / 
-                 math.Min(simResult.CPI, baselineData.CPI)
-        
-        t.Logf("%s: sim=%.3f, real=%.3f, error=%.1f%%",
-            simName, simResult.CPI, baselineData.CPI, error*100)
-        
-        if error > 0.02 {
-            t.Errorf("%s exceeds 2%% error threshold", simName)
-        }
-    }
+  ],
+  "analysis": {
+    "bias": "slight over-prediction",
+    "worst_case": "branch_heavy (3.5% error)",
+    "best_case": "arithmetic_seq (0.2% error)"
+  }
 }
 ```
 
-### 3. CI Integration
+### 3.2 Human-Readable Report
 
-Add to GitHub Actions workflow:
+Generate markdown report for PR comments and documentation:
+
+```markdown
+# M2Sim Accuracy Report
+
+**Result: ✅ PASS** (MAPE: 1.85% < 2.0% target)
+
+| Benchmark | Simulated | Measured | Error |
+|-----------|-----------|----------|-------|
+| loop_sim  | 1.02M     | 1.00M    | +2.0% |
+| matrix_op | 5.10M     | 5.05M    | +1.0% |
+| ...       | ...       | ...      | ...   |
+```
+
+## 4. CI Integration
+
+### 4.1 Accuracy Regression Test
 
 ```yaml
-- name: Run accuracy validation
-  run: go test ./benchmarks/... -run TestAccuracy -v
+# .github/workflows/accuracy.yml
+name: Accuracy Validation
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  accuracy:
+    runs-on: [self-hosted, m2]  # Requires M2 hardware runner
+    steps:
+      - uses: actions/checkout@v4
+      
+      - name: Build
+        run: make build
+        
+      - name: Collect Hardware Baseline
+        run: ./scripts/collect-hardware-baseline.sh
+        
+      - name: Run Simulator
+        run: ./bin/m2sim benchmark -format=json -o sim.json
+        
+      - name: Calculate Accuracy
+        run: ./scripts/accuracy-check.sh sim.json baseline.json
+        
+      - name: Post Results
+        if: github.event_name == 'pull_request'
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const report = require('./accuracy-report.json');
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `## Accuracy Report\n\n${report.markdown}`
+            });
 ```
 
-### 4. Accuracy Report Generation
+### 4.2 Baseline Management
 
-Create command to generate detailed accuracy report:
+**Storing Baselines:**
+- Hardware measurements stored in `baselines/m2-hardware.json`
+- Updated manually when hardware configuration changes
+- Version controlled with commit hash of measurement
 
-```bash
-go run ./cmd/benchmark -format=json -core > sim_results.json
-go run ./cmd/accuracy-report baseline=native/m2_baseline.json sim=sim_results.json
+**Baseline Update Process:**
+1. Run measurements on reference M2 hardware
+2. Run 10 iterations per benchmark
+3. Calculate mean and stddev
+4. Review and commit to `baselines/`
+
+## 5. Test Categories
+
+### 5.1 Core Validation Suite (Required for <2% target)
+
+| Test | Purpose | Weight |
+|------|---------|--------|
+| `loop_simulation_1M` | Basic loop overhead | High |
+| `arithmetic_1M` | ALU-bound workload | High |
+| `dependency_chain_100K` | Pipeline stall behavior | High |
+| `memory_sequential_1M` | L1 cache behavior | Medium |
+| `branch_heavy_1M` | Branch prediction accuracy | Medium |
+| `function_calls_100K` | Call/return overhead | Medium |
+
+### 5.2 Extended Validation (Informational)
+
+| Test | Purpose |
+|------|---------|
+| `l2_stress` | L2 cache behavior |
+| `random_memory` | Cache miss patterns |
+| `simd_basic` | NEON instruction timing |
+| `mixed_realistic` | Representative workload |
+
+## 6. Failure Analysis Procedures
+
+### 6.1 When Accuracy Drops Below 2%
+
+1. **Identify Regressing Benchmarks**
+   - Compare per-benchmark errors to previous baseline
+   - Flag benchmarks with >0.5% increase
+
+2. **Root Cause Analysis**
+   - Check recent commits affecting timing model
+   - Compare CPI breakdown (mem stalls, branch stalls, etc.)
+   - Review pipeline stage timings
+
+3. **Calibration Adjustment**
+   - If systematic bias: adjust global timing parameters
+   - If benchmark-specific: investigate instruction mix
+
+### 6.2 Tracking Error Trends
+
+Maintain `baselines/accuracy-history.json`:
+
+```json
+{
+  "history": [
+    {"date": "2026-02-01", "mape": 5.2, "version": "v0.5.0"},
+    {"date": "2026-02-03", "mape": 1.8, "version": "v0.6.0"}
+  ]
+}
 ```
 
-Output: `accuracy_report.md` with:
-- Per-benchmark comparison table
-- Error percentages
-- Pass/fail status for <2% target
-- Recommendations for calibration
+Plot accuracy over time to detect gradual drift.
 
-## Benchmark Mapping
+## 7. Implementation Checklist
 
-| Simulator Benchmark | M2 Baseline | What It Tests |
-|---------------------|-------------|---------------|
-| `arithmetic_sequential` | `arithmetic` | ALU throughput (ILP) |
-| `dependency_chain` | `dependency` | Pipeline forwarding |
-| `branch_taken` | `branch` | Branch prediction |
-| `memory_sequential` | (needed) | Memory latency |
-| `function_calls` | (needed) | Call/return overhead |
-| `matrix_operations` | (needed) | Load/compute/store |
-| `loop_simulation` | (needed) | Loop pattern |
-| `mixed_operations` | (needed) | Realistic workload |
+### Phase 1: Infrastructure (Issue #97)
+- [ ] Create `scripts/accuracy-check.sh` - Compare sim vs hardware JSON
+- [ ] Create `scripts/collect-hardware-baseline.sh` - xctrace wrapper
+- [ ] Define accuracy report JSON schema
+- [ ] Implement accuracy report generator in Go
 
-## Current Gap Analysis (Preliminary)
+### Phase 2: Benchmarks
+- [ ] Extend existing benchmarks to 1M+ iterations
+- [ ] Add iteration count CLI flag to benchmark harness
+- [ ] Validate determinism (same cycles every run)
 
-| Benchmark | Simulator CPI | Real M2 CPI | Error | Status |
-|-----------|---------------|-------------|-------|--------|
-| arithmetic | 1.200 | 0.268 | 348% | ❌ Need superscalar model |
-| dependency | 2.200 | 1.009 | 118% | ❌ Forwarding needs work |
-| branch | 2.900 | 1.190 | 144% | ❌ Branch prediction calibration |
+### Phase 3: CI Integration
+- [ ] Set up self-hosted M2 runner (or use manual baseline)
+- [ ] Add accuracy workflow to GitHub Actions
+- [ ] Configure PR comment posting
 
-## Recommendations
+### Phase 4: Baseline
+- [ ] Collect initial M2 hardware measurements
+- [ ] Document measurement methodology
+- [ ] Commit baseline to repository
 
-1. **Priority 1:** Fix forwarding path - dependency chain should be ~1 CPI
-2. **Priority 2:** Add superscalar issue model - arithmetic should be <1 CPI
-3. **Priority 3:** Calibrate branch predictor - branch should be ~1.2 CPI
-4. **Future:** Collect more baseline data for memory, function calls, etc.
+## 8. Success Criteria
 
-## Implementation Plan
+| Metric | Target | Measurement |
+|--------|--------|-------------|
+| MAPE | <2% | Average of all benchmarks |
+| Max Error | <5% | No single benchmark exceeds |
+| Bias | <1% | Signed error average near zero |
+| Variance | <0.5% | Simulator run-to-run variance |
 
-1. **Phase 1:** Create `accuracy_test.go` with basic comparison
-2. **Phase 2:** Add `accuracy-report` command for detailed analysis
-3. **Phase 3:** Integrate into CI as regression check
-4. **Phase 4:** Expand baselines for full benchmark coverage
+## Appendix A: Statistical Formulas
 
-## Success Criteria
+**Mean Absolute Percentage Error:**
+```
+MAPE = (100/n) × Σᵢ |(Aᵢ - Fᵢ) / Aᵢ|
+```
+Where Aᵢ = actual (hardware), Fᵢ = forecast (simulator)
 
-- [ ] Automated tests compare simulator vs baseline
-- [ ] Tests report error percentage per benchmark
-- [ ] CI fails if any benchmark exceeds 2% error
-- [ ] Accuracy report documents gaps and recommendations
+**Confidence Interval (95%):**
+```
+CI = x̄ ± 1.96 × (σ / √n)
+```
 
-## Notes
+**Coefficient of Variation:**
+```
+CV = σ / μ × 100%
+```
 
-- Current simulator is significantly slower than real M2 (higher CPI)
-- This is expected for initial implementation
-- Goal is to identify gaps and guide timing model improvements
-- <2% accuracy is ambitious - may need iterative calibration
+## Appendix B: Tools Required
+
+- `xcrun xctrace` - Apple Instruments CLI
+- `jq` - JSON processing
+- `go` - For accuracy analysis tool
+- GitHub Actions runner with M2 hardware (or manual baseline process)


### PR DESCRIPTION
## Summary
Adds comprehensive validation test plan for M6 accuracy analysis (Issue #97).

## Contents

The validation test plan covers:

### 1. Data Collection Strategy
- Hardware measurements via Apple Instruments (xctrace)
- Simulator benchmark harness integration
- Benchmark requirements (1M+ instructions for accuracy)

### 2. Error Calculation Methodology
- Per-benchmark absolute and signed error
- Aggregate metrics: MAPE, RMSE, Weighted MAPE
- Statistical confidence intervals (95% CI)

### 3. Report Generation
- JSON report schema for automation
- Human-readable markdown for PR comments
- Trend tracking over time

### 4. CI Integration
- GitHub Actions workflow design
- Self-hosted M2 runner requirements
- Baseline management procedures

### 5. Test Categories
- Core validation suite (6 benchmarks, required for <2% target)
- Extended validation suite (informational)

### 6. Failure Analysis Procedures
- Root cause analysis steps
- Calibration adjustment guidelines
- Error trend tracking

### 7. Implementation Checklist
- Phase 1-4 breakdown for Issue #97 implementation

## Addresses Alice's Questions
- **How will we compare simulated vs real timing data?** → Apple Instruments CPU Counters + JSON comparison
- **What statistical methods for measuring error?** → MAPE (primary), RMSE, confidence intervals

## Related Issues
- Closes #97 (documentation portion)
- Builds on PR #98 (M2 timing baseline)
- Enables PR #99 (benchmark harness) validation workflow