### PR TITLE
[Cathy] Integrate branch prediction into pipeline (Issue #106)

### DIFF
--- a/timing/pipeline/registers.go
+++ b/timing/pipeline/registers.go
@@ -13,6 +13,15 @@ type IFIDRegister struct {
 
 	// InstructionWord is the raw 32-bit instruction word.
 	InstructionWord uint32
+
+	// PredictedTaken indicates if the branch predictor predicted taken.
+	PredictedTaken bool
+
+	// PredictedTarget is the predicted branch target (from BTB or early resolution).
+	PredictedTarget uint64
+
+	// EarlyResolved indicates if this was an unconditional branch resolved at fetch time.
+	EarlyResolved bool
 }
 
 // Clear resets the IF/ID register to empty state.
@@ -20,6 +29,9 @@ func (r *IFIDRegister) Clear() {
 	r.Valid = false
 	r.PC = 0
 	r.InstructionWord = 0
+	r.PredictedTaken = false
+	r.PredictedTarget = 0
+	r.EarlyResolved = false
 }
 
 // IDEXRegister holds state between Decode and Execute stages.
@@ -48,6 +60,11 @@ type IDEXRegister struct {
 	RegWrite bool // True if instruction writes to register
 	MemToReg bool // True if result comes from memory (load)
 	IsBranch bool // True for branch instructions
+
+	// Branch prediction info (propagated from IF/ID).
+	PredictedTaken  bool   // Whether predicted taken
+	PredictedTarget uint64 // Predicted target address
+	EarlyResolved   bool   // Whether resolved at fetch time (unconditional branch)
 }
 
 // Clear resets the ID/EX register to empty state.
@@ -65,6 +82,9 @@ func (r *IDEXRegister) Clear() {
 	r.RegWrite = false
 	r.MemToReg = false
 	r.IsBranch = false
+	r.PredictedTaken = false
+	r.PredictedTarget = 0
+	r.EarlyResolved = false
 }
 
 // EXMEMRegister holds state between Execute and Memory stages.


### PR DESCRIPTION
## Problem

The `branch_taken` benchmark showed **101.7% error** in CPI prediction:
- Simulator CPI: 2.4
- Real M2 CPI: 1.19

## Root Cause Analysis

The branch predictor (2-bit saturating counter + BTB) existed in `branch_predictor.go` but was **never integrated into the pipeline**. Every taken branch caused a full pipeline flush (2 wasted cycles), regardless of predictability.

## Solution

1. **Integrated branch prediction** into the pipeline tick loop
2. **Added early branch resolution** for unconditional branches (B, BL):
   - Detects branch opcode during fetch from raw instruction word
   - Computes target immediately from the 26-bit immediate
   - Redirects fetch in the same cycle → no flush needed!
3. **Propagated prediction info** through pipeline registers (IF/ID → ID/EX)
4. **Execute stage verification**: Compare actual vs predicted outcome
   - Only flush on misprediction
   - Correct predictions incur zero penalty
5. **Updated tests** to reflect correct behavior

## Results

| Benchmark | Before | After | Improvement |
|-----------|--------|-------|-------------|
| branch_taken CPI | 2.4 | 1.4 | **17.6% error** (was 101.7%) |
| function_calls CPI | 2.6 | 1.9 | Also improved |

## Technical Details

### Early Branch Resolution
For unconditional branches (B, BL), the target is encoded directly in the instruction:
```go
// Detect B/BL: bits [31:26] = 000101 or 100101
// Extract signed 26-bit immediate, multiply by 4
target = PC + (sign_extend(imm26) * 4)
```

This allows us to redirect fetch **immediately** without waiting for BTB lookup, eliminating misprediction penalties for all unconditional branches.

### Pipeline Register Changes
Added to IFIDRegister and IDEXRegister:
- `PredictedTaken`: Whether branch was predicted taken
- `PredictedTarget`: Predicted target address
- `EarlyResolved`: Whether resolved at fetch time (unconditional)

## Files Changed
- `timing/pipeline/pipeline.go`: Branch prediction integration + early resolution
- `timing/pipeline/registers.go`: Prediction info fields
- `benchmarks/timing_validation_test.go`: Updated branch test expectations

## Verification
- All tests pass
- Branch prediction statistics tracked in pipeline stats

Fixes #106