### PR TITLE
[Bob] Implement 6-wide superscalar

### DIFF
--- a/timing/pipeline/pipeline.go
+++ b/timing/pipeline/pipeline.go
@@ -150,6 +150,18 @@ type Pipeline struct {
 	exmem4 QuaternaryEXMEMRegister
 	memwb4 QuaternaryMEMWBRegister
 
+	// Pipeline registers (quinary slot for 6-wide superscalar)
+	ifid5  QuinaryIFIDRegister
+	idex5  QuinaryIDEXRegister
+	exmem5 QuinaryEXMEMRegister
+	memwb5 QuinaryMEMWBRegister
+
+	// Pipeline registers (senary slot for 6-wide superscalar)
+	ifid6  SenaryIFIDRegister
+	idex6  SenaryIDEXRegister
+	exmem6 SenaryEXMEMRegister
+	memwb6 SenaryMEMWBRegister
+
 	// Pipeline stages
 	fetchStage     *FetchStage
 	decodeStage    *DecodeStage
@@ -175,6 +187,8 @@ type Pipeline struct {
 	exLatency2   uint64 // Remaining cycles for secondary execute slot
 	exLatency3   uint64 // Remaining cycles for tertiary execute slot
 	exLatency4   uint64 // Remaining cycles for quaternary execute slot
+	exLatency5   uint64 // Remaining cycles for quinary execute slot
+	exLatency6   uint64 // Remaining cycles for senary execute slot
 
 	// Non-cached memory latency tracking
 	memPending   bool   // True if waiting for memory operation to complete
@@ -319,6 +333,10 @@ func (p *Pipeline) Tick() {
 	p.stats.Cycles++
 
 	// Use superscalar tick if multi-issue is enabled
+	if p.superscalarConfig.IssueWidth >= 6 {
+		p.tickSextupleIssue()
+		return
+	}
 	if p.superscalarConfig.IssueWidth >= 4 {
 		p.tickQuadIssue()
 		return
@@ -2071,6 +2089,12 @@ func (p *Pipeline) forwardFromAllSlots(reg uint8, currentValue uint64) uint64 {
 	if p.memwb4.Valid && p.memwb4.RegWrite && p.memwb4.Rd == reg {
 		currentValue = p.memwb4.ALUResult
 	}
+	if p.memwb5.Valid && p.memwb5.RegWrite && p.memwb5.Rd == reg {
+		currentValue = p.memwb5.ALUResult
+	}
+	if p.memwb6.Valid && p.memwb6.RegWrite && p.memwb6.Rd == reg {
+		currentValue = p.memwb6.ALUResult
+	}
 
 	// Check exmem stages (newer, higher priority, primary slot first)
 	if p.exmem.Valid && p.exmem.RegWrite && p.exmem.Rd == reg {
@@ -2085,6 +2109,12 @@ func (p *Pipeline) forwardFromAllSlots(reg uint8, currentValue uint64) uint64 {
 	if p.exmem4.Valid && p.exmem4.RegWrite && p.exmem4.Rd == reg {
 		currentValue = p.exmem4.ALUResult
 	}
+	if p.exmem5.Valid && p.exmem5.RegWrite && p.exmem5.Rd == reg {
+		currentValue = p.exmem5.ALUResult
+	}
+	if p.exmem6.Valid && p.exmem6.RegWrite && p.exmem6.Rd == reg {
+		currentValue = p.exmem6.ALUResult
+	}
 
 	return currentValue
 }
@@ -2097,6 +2127,8 @@ func (p *Pipeline) flushAllIFID() {
 	p.ifid2.Clear()
 	p.ifid3.Clear()
 	p.ifid4.Clear()
+	p.ifid5.Clear()
+	p.ifid6.Clear()
 }
 
 // flushAllIDEX clears all ID/EX pipeline registers.
@@ -2107,6 +2139,1022 @@ func (p *Pipeline) flushAllIDEX() {
 	p.idex2.Clear()
 	p.idex3.Clear()
 	p.idex4.Clear()
+	p.idex5.Clear()
+	p.idex6.Clear()
+}
+
+// tickSextupleIssue executes one cycle with 6-wide superscalar support.
+// This extends 4-wide to match the Apple M2's 6 integer ALUs.
+func (p *Pipeline) tickSextupleIssue() {
+	// Stage 5: Writeback (all 6 slots)
+	savedMEMWB := p.memwb
+	p.writebackStage.Writeback(&p.memwb)
+	if p.memwb.Valid {
+		p.stats.Instructions++
+	}
+
+	// Writeback secondary slot
+	if p.memwb2.Valid && p.memwb2.RegWrite && p.memwb2.Rd != 31 {
+		var value uint64
+		if p.memwb2.MemToReg {
+			value = p.memwb2.MemData
+		} else {
+			value = p.memwb2.ALUResult
+		}
+		p.regFile.WriteReg(p.memwb2.Rd, value)
+		p.stats.Instructions++
+	}
+
+	// Writeback tertiary slot
+	if p.memwb3.Valid && p.memwb3.RegWrite && p.memwb3.Rd != 31 {
+		var value uint64
+		if p.memwb3.MemToReg {
+			value = p.memwb3.MemData
+		} else {
+			value = p.memwb3.ALUResult
+		}
+		p.regFile.WriteReg(p.memwb3.Rd, value)
+		p.stats.Instructions++
+	}
+
+	// Writeback quaternary slot
+	if p.memwb4.Valid && p.memwb4.RegWrite && p.memwb4.Rd != 31 {
+		var value uint64
+		if p.memwb4.MemToReg {
+			value = p.memwb4.MemData
+		} else {
+			value = p.memwb4.ALUResult
+		}
+		p.regFile.WriteReg(p.memwb4.Rd, value)
+		p.stats.Instructions++
+	}
+
+	// Writeback quinary slot
+	if p.memwb5.Valid && p.memwb5.RegWrite && p.memwb5.Rd != 31 {
+		var value uint64
+		if p.memwb5.MemToReg {
+			value = p.memwb5.MemData
+		} else {
+			value = p.memwb5.ALUResult
+		}
+		p.regFile.WriteReg(p.memwb5.Rd, value)
+		p.stats.Instructions++
+	}
+
+	// Writeback senary slot
+	if p.memwb6.Valid && p.memwb6.RegWrite && p.memwb6.Rd != 31 {
+		var value uint64
+		if p.memwb6.MemToReg {
+			value = p.memwb6.MemData
+		} else {
+			value = p.memwb6.ALUResult
+		}
+		p.regFile.WriteReg(p.memwb6.Rd, value)
+		p.stats.Instructions++
+	}
+
+	// Stage 4: Memory (primary slot only - single memory port)
+	var nextMEMWB MEMWBRegister
+	var nextMEMWB2 SecondaryMEMWBRegister
+	var nextMEMWB3 TertiaryMEMWBRegister
+	var nextMEMWB4 QuaternaryMEMWBRegister
+	var nextMEMWB5 QuinaryMEMWBRegister
+	var nextMEMWB6 SenaryMEMWBRegister
+	memStall := false
+
+	if p.exmem.Valid {
+		if p.exmem.Inst != nil && p.exmem.Inst.Op == insts.OpSVC {
+			if p.syscallHandler != nil {
+				result := p.syscallHandler.Handle()
+				if result.Exited {
+					p.halted = true
+					p.exitCode = result.ExitCode
+				}
+			}
+		}
+
+		var memResult MemoryResult
+		if p.useDCache && p.cachedMemoryStage != nil {
+			memResult, memStall = p.cachedMemoryStage.Access(&p.exmem)
+			if memStall {
+				p.stats.MemStalls++
+			}
+		} else {
+			if p.exmem.MemRead || p.exmem.MemWrite {
+				if p.memPending && p.memPendingPC != p.exmem.PC {
+					p.memPending = false
+				}
+				if !p.memPending {
+					p.memPending = true
+					p.memPendingPC = p.exmem.PC
+					memStall = true
+					p.stats.MemStalls++
+				} else {
+					p.memPending = false
+					memResult = p.memoryStage.Access(&p.exmem)
+				}
+			} else {
+				p.memPending = false
+			}
+		}
+
+		if !memStall {
+			nextMEMWB = MEMWBRegister{
+				Valid:     true,
+				PC:        p.exmem.PC,
+				Inst:      p.exmem.Inst,
+				ALUResult: p.exmem.ALUResult,
+				MemData:   memResult.MemData,
+				Rd:        p.exmem.Rd,
+				RegWrite:  p.exmem.RegWrite,
+				MemToReg:  p.exmem.MemToReg,
+			}
+		}
+	}
+
+	// Secondary slot memory (ALU results only, no memory access)
+	if p.exmem2.Valid && !memStall {
+		nextMEMWB2 = SecondaryMEMWBRegister{
+			Valid:     true,
+			PC:        p.exmem2.PC,
+			Inst:      p.exmem2.Inst,
+			ALUResult: p.exmem2.ALUResult,
+			MemData:   0,
+			Rd:        p.exmem2.Rd,
+			RegWrite:  p.exmem2.RegWrite,
+			MemToReg:  false,
+		}
+	}
+
+	// Tertiary slot memory (ALU results only)
+	if p.exmem3.Valid && !memStall {
+		nextMEMWB3 = TertiaryMEMWBRegister{
+			Valid:     true,
+			PC:        p.exmem3.PC,
+			Inst:      p.exmem3.Inst,
+			ALUResult: p.exmem3.ALUResult,
+			MemData:   0,
+			Rd:        p.exmem3.Rd,
+			RegWrite:  p.exmem3.RegWrite,
+			MemToReg:  false,
+		}
+	}
+
+	// Quaternary slot memory (ALU results only)
+	if p.exmem4.Valid && !memStall {
+		nextMEMWB4 = QuaternaryMEMWBRegister{
+			Valid:     true,
+			PC:        p.exmem4.PC,
+			Inst:      p.exmem4.Inst,
+			ALUResult: p.exmem4.ALUResult,
+			MemData:   0,
+			Rd:        p.exmem4.Rd,
+			RegWrite:  p.exmem4.RegWrite,
+			MemToReg:  false,
+		}
+	}
+
+	// Quinary slot memory (ALU results only)
+	if p.exmem5.Valid && !memStall {
+		nextMEMWB5 = QuinaryMEMWBRegister{
+			Valid:     true,
+			PC:        p.exmem5.PC,
+			Inst:      p.exmem5.Inst,
+			ALUResult: p.exmem5.ALUResult,
+			MemData:   0,
+			Rd:        p.exmem5.Rd,
+			RegWrite:  p.exmem5.RegWrite,
+			MemToReg:  false,
+		}
+	}
+
+	// Senary slot memory (ALU results only)
+	if p.exmem6.Valid && !memStall {
+		nextMEMWB6 = SenaryMEMWBRegister{
+			Valid:     true,
+			PC:        p.exmem6.PC,
+			Inst:      p.exmem6.Inst,
+			ALUResult: p.exmem6.ALUResult,
+			MemData:   0,
+			Rd:        p.exmem6.Rd,
+			RegWrite:  p.exmem6.RegWrite,
+			MemToReg:  false,
+		}
+	}
+
+	// Stage 3: Execute (all 6 slots)
+	var nextEXMEM EXMEMRegister
+	var nextEXMEM2 SecondaryEXMEMRegister
+	var nextEXMEM3 TertiaryEXMEMRegister
+	var nextEXMEM4 QuaternaryEXMEMRegister
+	var nextEXMEM5 QuinaryEXMEMRegister
+	var nextEXMEM6 SenaryEXMEMRegister
+	execStall := false
+
+	// Detect forwarding for primary slot
+	forwarding := p.hazardUnit.DetectForwarding(&p.idex, &p.exmem, &p.memwb)
+
+	// Execute primary slot
+	if p.idex.Valid && !memStall {
+		if p.latencyTable != nil && p.exLatency == 0 {
+			if p.useDCache && p.latencyTable.IsLoadOp(p.idex.Inst) {
+				p.exLatency = minCacheLoadLatency
+			} else {
+				p.exLatency = p.latencyTable.GetLatency(p.idex.Inst)
+			}
+		}
+
+		if p.exLatency > 0 {
+			p.exLatency--
+		}
+
+		if p.exLatency > 0 {
+			execStall = true
+			p.stats.ExecStalls++
+		} else {
+			rnValue := p.hazardUnit.GetForwardedValue(
+				forwarding.ForwardRn, p.idex.RnValue, &p.exmem, &savedMEMWB)
+			rmValue := p.hazardUnit.GetForwardedValue(
+				forwarding.ForwardRm, p.idex.RmValue, &p.exmem, &savedMEMWB)
+
+			// Forward from all secondary pipeline stages to primary slot
+			rnValue = p.forwardFromAllSlots(p.idex.Rn, rnValue)
+			rmValue = p.forwardFromAllSlots(p.idex.Rm, rmValue)
+
+			execResult := p.executeStage.Execute(&p.idex, rnValue, rmValue)
+
+			storeValue := execResult.StoreValue
+			if p.idex.MemWrite {
+				rdValue := p.regFile.ReadReg(p.idex.Rd)
+				storeValue = p.hazardUnit.GetForwardedValue(
+					forwarding.ForwardRd, rdValue, &p.exmem, &savedMEMWB)
+			}
+
+			nextEXMEM = EXMEMRegister{
+				Valid:      true,
+				PC:         p.idex.PC,
+				Inst:       p.idex.Inst,
+				ALUResult:  execResult.ALUResult,
+				StoreValue: storeValue,
+				Rd:         p.idex.Rd,
+				MemRead:    p.idex.MemRead,
+				MemWrite:   p.idex.MemWrite,
+				RegWrite:   p.idex.RegWrite,
+				MemToReg:   p.idex.MemToReg,
+			}
+
+			// Branch prediction verification for primary slot
+			if p.idex.IsBranch {
+				actualTaken := execResult.BranchTaken
+				actualTarget := execResult.BranchTarget
+
+				p.stats.BranchPredictions++
+
+				predictedTaken := p.idex.PredictedTaken
+				predictedTarget := p.idex.PredictedTarget
+				earlyResolved := p.idex.EarlyResolved
+
+				wasMispredicted := false
+				if actualTaken {
+					if !predictedTaken {
+						wasMispredicted = true
+					} else if predictedTarget != actualTarget {
+						wasMispredicted = true
+					}
+				} else {
+					if predictedTaken {
+						wasMispredicted = true
+					}
+				}
+
+				if earlyResolved && actualTaken {
+					wasMispredicted = false
+				}
+
+				p.branchPredictor.Update(p.idex.PC, actualTaken, actualTarget)
+
+				if wasMispredicted {
+					p.stats.BranchMispredictions++
+					branchTarget := actualTarget
+					if !actualTaken {
+						branchTarget = p.idex.PC + 4
+					}
+					p.pc = branchTarget
+					p.flushAllIFID()
+					p.flushAllIDEX()
+					p.stats.Flushes++
+
+					// Latch results and return early
+					if !memStall {
+						p.memwb = nextMEMWB
+						p.memwb2 = nextMEMWB2
+						p.memwb3 = nextMEMWB3
+						p.memwb4 = nextMEMWB4
+						p.memwb5 = nextMEMWB5
+						p.memwb6 = nextMEMWB6
+						p.exmem = nextEXMEM
+						p.exmem2.Clear()
+						p.exmem3.Clear()
+						p.exmem4.Clear()
+						p.exmem5.Clear()
+						p.exmem6.Clear()
+					}
+					return
+				}
+				p.stats.BranchCorrect++
+			}
+		}
+	}
+
+	// Execute secondary slot
+	if p.idex2.Valid && !memStall && !execStall {
+		if p.latencyTable != nil && p.exLatency2 == 0 {
+			p.exLatency2 = p.latencyTable.GetLatency(p.idex2.Inst)
+		}
+		if p.exLatency2 > 0 {
+			p.exLatency2--
+		}
+		if p.exLatency2 == 0 {
+			rnValue := p.forwardFromAllSlots(p.idex2.Rn, p.idex2.RnValue)
+			rmValue := p.forwardFromAllSlots(p.idex2.Rm, p.idex2.RmValue)
+			if nextEXMEM.Valid && nextEXMEM.RegWrite && nextEXMEM.Rd != 31 {
+				if p.idex2.Rn == nextEXMEM.Rd {
+					rnValue = nextEXMEM.ALUResult
+				}
+				if p.idex2.Rm == nextEXMEM.Rd {
+					rmValue = nextEXMEM.ALUResult
+				}
+			}
+			idex2 := p.idex2.toIDEX()
+			execResult := p.executeStage.Execute(&idex2, rnValue, rmValue)
+			nextEXMEM2 = SecondaryEXMEMRegister{
+				Valid:      true,
+				PC:         p.idex2.PC,
+				Inst:       p.idex2.Inst,
+				ALUResult:  execResult.ALUResult,
+				StoreValue: execResult.StoreValue,
+				Rd:         p.idex2.Rd,
+				MemRead:    p.idex2.MemRead,
+				MemWrite:   p.idex2.MemWrite,
+				RegWrite:   p.idex2.RegWrite,
+				MemToReg:   p.idex2.MemToReg,
+			}
+		}
+	}
+
+	// Execute tertiary slot
+	if p.idex3.Valid && !memStall && !execStall {
+		if p.latencyTable != nil && p.exLatency3 == 0 {
+			p.exLatency3 = p.latencyTable.GetLatency(p.idex3.Inst)
+		}
+		if p.exLatency3 > 0 {
+			p.exLatency3--
+		}
+		if p.exLatency3 == 0 {
+			rnValue := p.forwardFromAllSlots(p.idex3.Rn, p.idex3.RnValue)
+			rmValue := p.forwardFromAllSlots(p.idex3.Rm, p.idex3.RmValue)
+			if nextEXMEM.Valid && nextEXMEM.RegWrite && nextEXMEM.Rd != 31 {
+				if p.idex3.Rn == nextEXMEM.Rd {
+					rnValue = nextEXMEM.ALUResult
+				}
+				if p.idex3.Rm == nextEXMEM.Rd {
+					rmValue = nextEXMEM.ALUResult
+				}
+			}
+			if nextEXMEM2.Valid && nextEXMEM2.RegWrite && nextEXMEM2.Rd != 31 {
+				if p.idex3.Rn == nextEXMEM2.Rd {
+					rnValue = nextEXMEM2.ALUResult
+				}
+				if p.idex3.Rm == nextEXMEM2.Rd {
+					rmValue = nextEXMEM2.ALUResult
+				}
+			}
+			idex3 := p.idex3.toIDEX()
+			execResult := p.executeStage.Execute(&idex3, rnValue, rmValue)
+			nextEXMEM3 = TertiaryEXMEMRegister{
+				Valid:      true,
+				PC:         p.idex3.PC,
+				Inst:       p.idex3.Inst,
+				ALUResult:  execResult.ALUResult,
+				StoreValue: execResult.StoreValue,
+				Rd:         p.idex3.Rd,
+				MemRead:    p.idex3.MemRead,
+				MemWrite:   p.idex3.MemWrite,
+				RegWrite:   p.idex3.RegWrite,
+				MemToReg:   p.idex3.MemToReg,
+			}
+		}
+	}
+
+	// Execute quaternary slot
+	if p.idex4.Valid && !memStall && !execStall {
+		if p.latencyTable != nil && p.exLatency4 == 0 {
+			p.exLatency4 = p.latencyTable.GetLatency(p.idex4.Inst)
+		}
+		if p.exLatency4 > 0 {
+			p.exLatency4--
+		}
+		if p.exLatency4 == 0 {
+			rnValue := p.forwardFromAllSlots(p.idex4.Rn, p.idex4.RnValue)
+			rmValue := p.forwardFromAllSlots(p.idex4.Rm, p.idex4.RmValue)
+			if nextEXMEM.Valid && nextEXMEM.RegWrite && nextEXMEM.Rd != 31 {
+				if p.idex4.Rn == nextEXMEM.Rd {
+					rnValue = nextEXMEM.ALUResult
+				}
+				if p.idex4.Rm == nextEXMEM.Rd {
+					rmValue = nextEXMEM.ALUResult
+				}
+			}
+			if nextEXMEM2.Valid && nextEXMEM2.RegWrite && nextEXMEM2.Rd != 31 {
+				if p.idex4.Rn == nextEXMEM2.Rd {
+					rnValue = nextEXMEM2.ALUResult
+				}
+				if p.idex4.Rm == nextEXMEM2.Rd {
+					rmValue = nextEXMEM2.ALUResult
+				}
+			}
+			if nextEXMEM3.Valid && nextEXMEM3.RegWrite && nextEXMEM3.Rd != 31 {
+				if p.idex4.Rn == nextEXMEM3.Rd {
+					rnValue = nextEXMEM3.ALUResult
+				}
+				if p.idex4.Rm == nextEXMEM3.Rd {
+					rmValue = nextEXMEM3.ALUResult
+				}
+			}
+			idex4 := p.idex4.toIDEX()
+			execResult := p.executeStage.Execute(&idex4, rnValue, rmValue)
+			nextEXMEM4 = QuaternaryEXMEMRegister{
+				Valid:      true,
+				PC:         p.idex4.PC,
+				Inst:       p.idex4.Inst,
+				ALUResult:  execResult.ALUResult,
+				StoreValue: execResult.StoreValue,
+				Rd:         p.idex4.Rd,
+				MemRead:    p.idex4.MemRead,
+				MemWrite:   p.idex4.MemWrite,
+				RegWrite:   p.idex4.RegWrite,
+				MemToReg:   p.idex4.MemToReg,
+			}
+		}
+	}
+
+	// Execute quinary slot
+	if p.idex5.Valid && !memStall && !execStall {
+		if p.latencyTable != nil && p.exLatency5 == 0 {
+			p.exLatency5 = p.latencyTable.GetLatency(p.idex5.Inst)
+		}
+		if p.exLatency5 > 0 {
+			p.exLatency5--
+		}
+		if p.exLatency5 == 0 {
+			rnValue := p.forwardFromAllSlots(p.idex5.Rn, p.idex5.RnValue)
+			rmValue := p.forwardFromAllSlots(p.idex5.Rm, p.idex5.RmValue)
+			if nextEXMEM.Valid && nextEXMEM.RegWrite && nextEXMEM.Rd != 31 {
+				if p.idex5.Rn == nextEXMEM.Rd {
+					rnValue = nextEXMEM.ALUResult
+				}
+				if p.idex5.Rm == nextEXMEM.Rd {
+					rmValue = nextEXMEM.ALUResult
+				}
+			}
+			if nextEXMEM2.Valid && nextEXMEM2.RegWrite && nextEXMEM2.Rd != 31 {
+				if p.idex5.Rn == nextEXMEM2.Rd {
+					rnValue = nextEXMEM2.ALUResult
+				}
+				if p.idex5.Rm == nextEXMEM2.Rd {
+					rmValue = nextEXMEM2.ALUResult
+				}
+			}
+			if nextEXMEM3.Valid && nextEXMEM3.RegWrite && nextEXMEM3.Rd != 31 {
+				if p.idex5.Rn == nextEXMEM3.Rd {
+					rnValue = nextEXMEM3.ALUResult
+				}
+				if p.idex5.Rm == nextEXMEM3.Rd {
+					rmValue = nextEXMEM3.ALUResult
+				}
+			}
+			if nextEXMEM4.Valid && nextEXMEM4.RegWrite && nextEXMEM4.Rd != 31 {
+				if p.idex5.Rn == nextEXMEM4.Rd {
+					rnValue = nextEXMEM4.ALUResult
+				}
+				if p.idex5.Rm == nextEXMEM4.Rd {
+					rmValue = nextEXMEM4.ALUResult
+				}
+			}
+			idex5 := p.idex5.toIDEX()
+			execResult := p.executeStage.Execute(&idex5, rnValue, rmValue)
+			nextEXMEM5 = QuinaryEXMEMRegister{
+				Valid:      true,
+				PC:         p.idex5.PC,
+				Inst:       p.idex5.Inst,
+				ALUResult:  execResult.ALUResult,
+				StoreValue: execResult.StoreValue,
+				Rd:         p.idex5.Rd,
+				MemRead:    p.idex5.MemRead,
+				MemWrite:   p.idex5.MemWrite,
+				RegWrite:   p.idex5.RegWrite,
+				MemToReg:   p.idex5.MemToReg,
+			}
+		}
+	}
+
+	// Execute senary slot
+	if p.idex6.Valid && !memStall && !execStall {
+		if p.latencyTable != nil && p.exLatency6 == 0 {
+			p.exLatency6 = p.latencyTable.GetLatency(p.idex6.Inst)
+		}
+		if p.exLatency6 > 0 {
+			p.exLatency6--
+		}
+		if p.exLatency6 == 0 {
+			rnValue := p.forwardFromAllSlots(p.idex6.Rn, p.idex6.RnValue)
+			rmValue := p.forwardFromAllSlots(p.idex6.Rm, p.idex6.RmValue)
+			if nextEXMEM.Valid && nextEXMEM.RegWrite && nextEXMEM.Rd != 31 {
+				if p.idex6.Rn == nextEXMEM.Rd {
+					rnValue = nextEXMEM.ALUResult
+				}
+				if p.idex6.Rm == nextEXMEM.Rd {
+					rmValue = nextEXMEM.ALUResult
+				}
+			}
+			if nextEXMEM2.Valid && nextEXMEM2.RegWrite && nextEXMEM2.Rd != 31 {
+				if p.idex6.Rn == nextEXMEM2.Rd {
+					rnValue = nextEXMEM2.ALUResult
+				}
+				if p.idex6.Rm == nextEXMEM2.Rd {
+					rmValue = nextEXMEM2.ALUResult
+				}
+			}
+			if nextEXMEM3.Valid && nextEXMEM3.RegWrite && nextEXMEM3.Rd != 31 {
+				if p.idex6.Rn == nextEXMEM3.Rd {
+					rnValue = nextEXMEM3.ALUResult
+				}
+				if p.idex6.Rm == nextEXMEM3.Rd {
+					rmValue = nextEXMEM3.ALUResult
+				}
+			}
+			if nextEXMEM4.Valid && nextEXMEM4.RegWrite && nextEXMEM4.Rd != 31 {
+				if p.idex6.Rn == nextEXMEM4.Rd {
+					rnValue = nextEXMEM4.ALUResult
+				}
+				if p.idex6.Rm == nextEXMEM4.Rd {
+					rmValue = nextEXMEM4.ALUResult
+				}
+			}
+			if nextEXMEM5.Valid && nextEXMEM5.RegWrite && nextEXMEM5.Rd != 31 {
+				if p.idex6.Rn == nextEXMEM5.Rd {
+					rnValue = nextEXMEM5.ALUResult
+				}
+				if p.idex6.Rm == nextEXMEM5.Rd {
+					rmValue = nextEXMEM5.ALUResult
+				}
+			}
+			idex6 := p.idex6.toIDEX()
+			execResult := p.executeStage.Execute(&idex6, rnValue, rmValue)
+			nextEXMEM6 = SenaryEXMEMRegister{
+				Valid:      true,
+				PC:         p.idex6.PC,
+				Inst:       p.idex6.Inst,
+				ALUResult:  execResult.ALUResult,
+				StoreValue: execResult.StoreValue,
+				Rd:         p.idex6.Rd,
+				MemRead:    p.idex6.MemRead,
+				MemWrite:   p.idex6.MemWrite,
+				RegWrite:   p.idex6.RegWrite,
+				MemToReg:   p.idex6.MemToReg,
+			}
+		}
+	}
+
+	// Detect load-use hazards for primary decode
+	loadUseHazard := false
+	if p.idex.Valid && p.idex.MemRead && p.idex.Rd != 31 && p.ifid.Valid {
+		nextInst := p.decodeStage.decoder.Decode(p.ifid.InstructionWord)
+		if nextInst != nil && nextInst.Op != insts.OpUnknown {
+			usesRn := true
+			usesRm := nextInst.Format == insts.FormatDPReg
+
+			sourceRm := nextInst.Rm
+			switch nextInst.Op {
+			case insts.OpSTR, insts.OpSTRQ:
+				usesRm = true
+				sourceRm = nextInst.Rd
+			}
+
+			loadUseHazard = p.hazardUnit.DetectLoadUseHazardDecoded(
+				p.idex.Rd, nextInst.Rn, sourceRm, usesRn, usesRm)
+		}
+	}
+
+	stallResult := p.hazardUnit.ComputeStalls(loadUseHazard || execStall || memStall, false)
+
+	// Stage 2: Decode (all 6 slots)
+	var nextIDEX IDEXRegister
+	var nextIDEX2 SecondaryIDEXRegister
+	var nextIDEX3 TertiaryIDEXRegister
+	var nextIDEX4 QuaternaryIDEXRegister
+	var nextIDEX5 QuinaryIDEXRegister
+	var nextIDEX6 SenaryIDEXRegister
+
+	if p.ifid.Valid && !stallResult.StallID && !stallResult.FlushID && !execStall && !memStall {
+		decResult := p.decodeStage.Decode(p.ifid.InstructionWord, p.ifid.PC)
+		nextIDEX = IDEXRegister{
+			Valid:           true,
+			PC:              p.ifid.PC,
+			Inst:            decResult.Inst,
+			RnValue:         decResult.RnValue,
+			RmValue:         decResult.RmValue,
+			Rd:              decResult.Rd,
+			Rn:              decResult.Rn,
+			Rm:              decResult.Rm,
+			MemRead:         decResult.MemRead,
+			MemWrite:        decResult.MemWrite,
+			RegWrite:        decResult.RegWrite,
+			MemToReg:        decResult.MemToReg,
+			IsBranch:        decResult.IsBranch,
+			PredictedTaken:  p.ifid.PredictedTaken,
+			PredictedTarget: p.ifid.PredictedTarget,
+			EarlyResolved:   p.ifid.EarlyResolved,
+		}
+
+		// Try to issue instructions 2-6 if they can issue with earlier instructions
+		issuedInsts := []*IDEXRegister{&nextIDEX}
+
+		// Decode slot 2
+		if p.ifid2.Valid {
+			decResult2 := p.decodeStage.Decode(p.ifid2.InstructionWord, p.ifid2.PC)
+			tempIDEX2 := IDEXRegister{
+				Valid:    true,
+				PC:       p.ifid2.PC,
+				Inst:     decResult2.Inst,
+				RnValue:  decResult2.RnValue,
+				RmValue:  decResult2.RmValue,
+				Rd:       decResult2.Rd,
+				Rn:       decResult2.Rn,
+				Rm:       decResult2.Rm,
+				MemRead:  decResult2.MemRead,
+				MemWrite: decResult2.MemWrite,
+				RegWrite: decResult2.RegWrite,
+				MemToReg: decResult2.MemToReg,
+				IsBranch: decResult2.IsBranch,
+			}
+			if canIssueWith(&tempIDEX2, issuedInsts) {
+				nextIDEX2.fromIDEX(&tempIDEX2)
+				issuedInsts = append(issuedInsts, &tempIDEX2)
+			}
+		}
+
+		// Decode slot 3
+		if p.ifid3.Valid && nextIDEX2.Valid {
+			decResult3 := p.decodeStage.Decode(p.ifid3.InstructionWord, p.ifid3.PC)
+			tempIDEX3 := IDEXRegister{
+				Valid:    true,
+				PC:       p.ifid3.PC,
+				Inst:     decResult3.Inst,
+				RnValue:  decResult3.RnValue,
+				RmValue:  decResult3.RmValue,
+				Rd:       decResult3.Rd,
+				Rn:       decResult3.Rn,
+				Rm:       decResult3.Rm,
+				MemRead:  decResult3.MemRead,
+				MemWrite: decResult3.MemWrite,
+				RegWrite: decResult3.RegWrite,
+				MemToReg: decResult3.MemToReg,
+				IsBranch: decResult3.IsBranch,
+			}
+			if canIssueWith(&tempIDEX3, issuedInsts) {
+				nextIDEX3.fromIDEX(&tempIDEX3)
+				issuedInsts = append(issuedInsts, &tempIDEX3)
+			}
+		}
+
+		// Decode slot 4
+		if p.ifid4.Valid && nextIDEX3.Valid {
+			decResult4 := p.decodeStage.Decode(p.ifid4.InstructionWord, p.ifid4.PC)
+			tempIDEX4 := IDEXRegister{
+				Valid:    true,
+				PC:       p.ifid4.PC,
+				Inst:     decResult4.Inst,
+				RnValue:  decResult4.RnValue,
+				RmValue:  decResult4.RmValue,
+				Rd:       decResult4.Rd,
+				Rn:       decResult4.Rn,
+				Rm:       decResult4.Rm,
+				MemRead:  decResult4.MemRead,
+				MemWrite: decResult4.MemWrite,
+				RegWrite: decResult4.RegWrite,
+				MemToReg: decResult4.MemToReg,
+				IsBranch: decResult4.IsBranch,
+			}
+			if canIssueWith(&tempIDEX4, issuedInsts) {
+				nextIDEX4.fromIDEX(&tempIDEX4)
+				issuedInsts = append(issuedInsts, &tempIDEX4)
+			}
+		}
+
+		// Decode slot 5
+		if p.ifid5.Valid && nextIDEX4.Valid {
+			decResult5 := p.decodeStage.Decode(p.ifid5.InstructionWord, p.ifid5.PC)
+			tempIDEX5 := IDEXRegister{
+				Valid:    true,
+				PC:       p.ifid5.PC,
+				Inst:     decResult5.Inst,
+				RnValue:  decResult5.RnValue,
+				RmValue:  decResult5.RmValue,
+				Rd:       decResult5.Rd,
+				Rn:       decResult5.Rn,
+				Rm:       decResult5.Rm,
+				MemRead:  decResult5.MemRead,
+				MemWrite: decResult5.MemWrite,
+				RegWrite: decResult5.RegWrite,
+				MemToReg: decResult5.MemToReg,
+				IsBranch: decResult5.IsBranch,
+			}
+			if canIssueWith(&tempIDEX5, issuedInsts) {
+				nextIDEX5.fromIDEX(&tempIDEX5)
+				issuedInsts = append(issuedInsts, &tempIDEX5)
+			}
+		}
+
+		// Decode slot 6
+		if p.ifid6.Valid && nextIDEX5.Valid {
+			decResult6 := p.decodeStage.Decode(p.ifid6.InstructionWord, p.ifid6.PC)
+			tempIDEX6 := IDEXRegister{
+				Valid:    true,
+				PC:       p.ifid6.PC,
+				Inst:     decResult6.Inst,
+				RnValue:  decResult6.RnValue,
+				RmValue:  decResult6.RmValue,
+				Rd:       decResult6.Rd,
+				Rn:       decResult6.Rn,
+				Rm:       decResult6.Rm,
+				MemRead:  decResult6.MemRead,
+				MemWrite: decResult6.MemWrite,
+				RegWrite: decResult6.RegWrite,
+				MemToReg: decResult6.MemToReg,
+				IsBranch: decResult6.IsBranch,
+			}
+			if canIssueWith(&tempIDEX6, issuedInsts) {
+				nextIDEX6.fromIDEX(&tempIDEX6)
+			}
+		}
+	} else if (stallResult.StallID || execStall || memStall) && !stallResult.FlushID {
+		nextIDEX = p.idex
+		nextIDEX2 = p.idex2
+		nextIDEX3 = p.idex3
+		nextIDEX4 = p.idex4
+		nextIDEX5 = p.idex5
+		nextIDEX6 = p.idex6
+	}
+
+	// Count how many instructions were issued this cycle for fetch advancement
+	issueCount := 0
+	if nextIDEX.Valid {
+		issueCount++
+	}
+	if nextIDEX2.Valid {
+		issueCount++
+	}
+	if nextIDEX3.Valid {
+		issueCount++
+	}
+	if nextIDEX4.Valid {
+		issueCount++
+	}
+	if nextIDEX5.Valid {
+		issueCount++
+	}
+	if nextIDEX6.Valid {
+		issueCount++
+	}
+
+	// Stage 1: Fetch (all 6 slots)
+	var nextIFID IFIDRegister
+	var nextIFID2 SecondaryIFIDRegister
+	var nextIFID3 TertiaryIFIDRegister
+	var nextIFID4 QuaternaryIFIDRegister
+	var nextIFID5 QuinaryIFIDRegister
+	var nextIFID6 SenaryIFIDRegister
+	fetchStall := false
+
+	if !stallResult.StallIF && !stallResult.FlushIF && !memStall && !execStall {
+		// Shift unissued instructions forward
+		pendingInsts := p.collectPendingFetchInstructions6(issueCount)
+
+		// Fill slots with pending instructions first, then fetch new ones
+		fetchPC := p.pc
+		slotIdx := 0
+
+		// Place pending instructions
+		branchPredictedTaken := false
+		for _, pending := range pendingInsts {
+			if branchPredictedTaken {
+				break
+			}
+			switch slotIdx {
+			case 0:
+				isUncondBranch, uncondTarget := isUnconditionalBranch(pending.Word, pending.PC)
+				pred := p.branchPredictor.Predict(pending.PC)
+				earlyResolved := false
+				if isUncondBranch {
+					pred.Taken = true
+					pred.Target = uncondTarget
+					pred.TargetKnown = true
+					earlyResolved = true
+				}
+				nextIFID = IFIDRegister{
+					Valid:           true,
+					PC:              pending.PC,
+					InstructionWord: pending.Word,
+					PredictedTaken:  pred.Taken,
+					PredictedTarget: pred.Target,
+					EarlyResolved:   earlyResolved,
+				}
+				if pred.Taken && pred.TargetKnown {
+					fetchPC = pred.Target
+					branchPredictedTaken = true
+				}
+			case 1:
+				nextIFID2 = SecondaryIFIDRegister{Valid: true, PC: pending.PC, InstructionWord: pending.Word}
+			case 2:
+				nextIFID3 = TertiaryIFIDRegister{Valid: true, PC: pending.PC, InstructionWord: pending.Word}
+			case 3:
+				nextIFID4 = QuaternaryIFIDRegister{Valid: true, PC: pending.PC, InstructionWord: pending.Word}
+			case 4:
+				nextIFID5 = QuinaryIFIDRegister{Valid: true, PC: pending.PC, InstructionWord: pending.Word}
+			case 5:
+				nextIFID6 = SenaryIFIDRegister{Valid: true, PC: pending.PC, InstructionWord: pending.Word}
+			}
+			slotIdx++
+		}
+
+		// Fetch new instructions to fill remaining slots
+		for slotIdx < 6 {
+			var word uint32
+			var ok bool
+
+			if p.useICache && p.cachedFetchStage != nil {
+				word, ok, fetchStall = p.cachedFetchStage.Fetch(fetchPC)
+				if fetchStall {
+					p.stats.Stalls++
+					break
+				}
+			} else {
+				word, ok = p.fetchStage.Fetch(fetchPC)
+			}
+
+			if !ok {
+				break
+			}
+
+			if slotIdx == 0 {
+				isUncondBranch, uncondTarget := isUnconditionalBranch(word, fetchPC)
+				pred := p.branchPredictor.Predict(fetchPC)
+				earlyResolved := false
+				if isUncondBranch {
+					pred.Taken = true
+					pred.Target = uncondTarget
+					pred.TargetKnown = true
+					earlyResolved = true
+				}
+				nextIFID = IFIDRegister{
+					Valid:           true,
+					PC:              fetchPC,
+					InstructionWord: word,
+					PredictedTaken:  pred.Taken,
+					PredictedTarget: pred.Target,
+					EarlyResolved:   earlyResolved,
+				}
+				if pred.Taken && pred.TargetKnown {
+					fetchPC = pred.Target
+					slotIdx++
+					continue
+				}
+			} else {
+				switch slotIdx {
+				case 1:
+					nextIFID2 = SecondaryIFIDRegister{Valid: true, PC: fetchPC, InstructionWord: word}
+				case 2:
+					nextIFID3 = TertiaryIFIDRegister{Valid: true, PC: fetchPC, InstructionWord: word}
+				case 3:
+					nextIFID4 = QuaternaryIFIDRegister{Valid: true, PC: fetchPC, InstructionWord: word}
+				case 4:
+					nextIFID5 = QuinaryIFIDRegister{Valid: true, PC: fetchPC, InstructionWord: word}
+				case 5:
+					nextIFID6 = SenaryIFIDRegister{Valid: true, PC: fetchPC, InstructionWord: word}
+				}
+			}
+			fetchPC += 4
+			slotIdx++
+		}
+		p.pc = fetchPC
+
+		if fetchStall {
+			nextIFID = p.ifid
+			nextIFID2 = p.ifid2
+			nextIFID3 = p.ifid3
+			nextIFID4 = p.ifid4
+			nextIFID5 = p.ifid5
+			nextIFID6 = p.ifid6
+			nextIDEX = p.idex
+			nextIDEX2 = p.idex2
+			nextIDEX3 = p.idex3
+			nextIDEX4 = p.idex4
+			nextIDEX5 = p.idex5
+			nextIDEX6 = p.idex6
+			nextEXMEM = p.exmem
+			nextEXMEM2 = p.exmem2
+			nextEXMEM3 = p.exmem3
+			nextEXMEM4 = p.exmem4
+			nextEXMEM5 = p.exmem5
+			nextEXMEM6 = p.exmem6
+		}
+	} else if (stallResult.StallIF || memStall || execStall) && !stallResult.FlushIF {
+		nextIFID = p.ifid
+		nextIFID2 = p.ifid2
+		nextIFID3 = p.ifid3
+		nextIFID4 = p.ifid4
+		nextIFID5 = p.ifid5
+		nextIFID6 = p.ifid6
+		p.stats.Stalls++
+	}
+
+	// Latch all pipeline registers
+	if !memStall && !fetchStall {
+		p.memwb = nextMEMWB
+		p.memwb2 = nextMEMWB2
+		p.memwb3 = nextMEMWB3
+		p.memwb4 = nextMEMWB4
+		p.memwb5 = nextMEMWB5
+		p.memwb6 = nextMEMWB6
+	} else {
+		p.memwb.Clear()
+		p.memwb2.Clear()
+		p.memwb3.Clear()
+		p.memwb4.Clear()
+		p.memwb5.Clear()
+		p.memwb6.Clear()
+	}
+	if !execStall && !memStall {
+		p.exmem = nextEXMEM
+		p.exmem2 = nextEXMEM2
+		p.exmem3 = nextEXMEM3
+		p.exmem4 = nextEXMEM4
+		p.exmem5 = nextEXMEM5
+		p.exmem6 = nextEXMEM6
+	}
+	if stallResult.InsertBubbleEX && !execStall && !memStall {
+		p.idex.Clear()
+		p.idex2.Clear()
+		p.idex3.Clear()
+		p.idex4.Clear()
+		p.idex5.Clear()
+		p.idex6.Clear()
+	} else if !memStall {
+		p.idex = nextIDEX
+		p.idex2 = nextIDEX2
+		p.idex3 = nextIDEX3
+		p.idex4 = nextIDEX4
+		p.idex5 = nextIDEX5
+		p.idex6 = nextIDEX6
+	}
+	p.ifid = nextIFID
+	p.ifid2 = nextIFID2
+	p.ifid3 = nextIFID3
+	p.ifid4 = nextIFID4
+	p.ifid5 = nextIFID5
+	p.ifid6 = nextIFID6
+}
+
+// collectPendingFetchInstructions6 returns unissued instructions for 6-wide.
+func (p *Pipeline) collectPendingFetchInstructions6(issueCount int) []pendingFetchInst {
+	var pending []pendingFetchInst
+
+	allFetched := []pendingFetchInst{}
+	if p.ifid.Valid {
+		allFetched = append(allFetched, pendingFetchInst{PC: p.ifid.PC, Word: p.ifid.InstructionWord})
+	}
+	if p.ifid2.Valid {
+		allFetched = append(allFetched, pendingFetchInst{PC: p.ifid2.PC, Word: p.ifid2.InstructionWord})
+	}
+	if p.ifid3.Valid {
+		allFetched = append(allFetched, pendingFetchInst{PC: p.ifid3.PC, Word: p.ifid3.InstructionWord})
+	}
+	if p.ifid4.Valid {
+		allFetched = append(allFetched, pendingFetchInst{PC: p.ifid4.PC, Word: p.ifid4.InstructionWord})
+	}
+	if p.ifid5.Valid {
+		allFetched = append(allFetched, pendingFetchInst{PC: p.ifid5.PC, Word: p.ifid5.InstructionWord})
+	}
+	if p.ifid6.Valid {
+		allFetched = append(allFetched, pendingFetchInst{PC: p.ifid6.PC, Word: p.ifid6.InstructionWord})
+	}
+
+	if issueCount < len(allFetched) {
+		pending = allFetched[issueCount:]
+	}
+
+	return pending
 }
 
 // Reset clears all pipeline state.
@@ -2127,6 +3175,14 @@ func (p *Pipeline) Reset() {
 	p.idex4.Clear()
 	p.exmem4.Clear()
 	p.memwb4.Clear()
+	p.ifid5.Clear()
+	p.idex5.Clear()
+	p.exmem5.Clear()
+	p.memwb5.Clear()
+	p.ifid6.Clear()
+	p.idex6.Clear()
+	p.exmem6.Clear()
+	p.memwb6.Clear()
 	p.pc = 0
 	p.stats = Statistics{}
 	p.halted = false
@@ -2134,6 +3190,8 @@ func (p *Pipeline) Reset() {
 	p.exLatency2 = 0
 	p.exLatency3 = 0
 	p.exLatency4 = 0
+	p.exLatency5 = 0
+	p.exLatency6 = 0
 	p.memPending = false
 	p.memPendingPC = 0
 	if p.branchPredictor != nil {


### PR DESCRIPTION
Closes #118

## Summary
Extend pipeline from 4-wide to 6-wide superscalar to match Apple M2's 6 integer ALUs.

## Changes
- Add `SextupleIssueConfig()` and `WithSextupleIssue()` in superscalar.go
- Add Quinary (5th slot) and Senary (6th slot) pipeline registers for all stages
- Implement `tickSextupleIssue()` with full 6-way issue, decode, execute, and writeback
- Update benchmark harness to use 6-wide by default
- Update `forwardFromAllSlots()`, `flushAllIFID()`, `flushAllIDEX()`, and `Reset()`

## Results
Based on Cathy's analysis (ARITHMETIC_THROUGHPUT_ANALYSIS.md):

| Benchmark | 4-wide CPI | 6-wide CPI | 4-wide Error | 6-wide Error |
|-----------|------------|------------|--------------|--------------|
| arithmetic_sequential | 0.450 | 0.400 | 67.9% | 49.3% |

The improvement is less than expected (~35% error predicted), likely due to:
- Pipeline fill/drain overhead
- Branch prediction interactions

## Testing
- All 159 pipeline tests pass
- All accuracy tests pass
- All emu/insts/loader/cache tests pass