### PR TITLE
[Bob] Implement branch elimination for unconditional B

### DIFF
--- a/benchmarks/timing_harness.go
+++ b/benchmarks/timing_harness.go
@@ -45,6 +45,10 @@ type BenchmarkResult struct {
 	// PipelineFlushes is the number of pipeline flushes
 	PipelineFlushes uint64 `json:"pipeline_flushes"`
 
+	// EliminatedBranches is the count of unconditional branches (B, not BL)
+	// that were eliminated at fetch time and never entered the pipeline
+	EliminatedBranches uint64 `json:"eliminated_branches"`
+
 	// ICacheHits/Misses (if cache enabled)
 	ICacheHits   uint64 `json:"icache_hits,omitempty"`
 	ICacheMisses uint64 `json:"icache_misses,omitempty"`
@@ -209,6 +213,7 @@ func (h *Harness) runBenchmark(bench Benchmark) BenchmarkResult {
 		MemStalls:           stats.MemStalls,
 		DataHazards:         stats.DataHazards,
 		PipelineFlushes:     stats.Flushes,
+		EliminatedBranches:  stats.EliminatedBranches,
 		ExitCode:            exitCode,
 		WallTime:            wallTime,
 	}
@@ -246,6 +251,9 @@ func (h *Harness) PrintResults(results []BenchmarkResult) {
 		_, _ = fmt.Fprintf(h.config.Output, "  Mem Stalls:           %d\n", r.MemStalls)
 		_, _ = fmt.Fprintf(h.config.Output, "  Data Hazards:         %d\n", r.DataHazards)
 		_, _ = fmt.Fprintf(h.config.Output, "  Pipeline Flushes:     %d\n", r.PipelineFlushes)
+		if r.EliminatedBranches > 0 {
+			_, _ = fmt.Fprintf(h.config.Output, "  Eliminated Branches:  %d\n", r.EliminatedBranches)
+		}
 
 		if r.ICacheHits > 0 || r.ICacheMisses > 0 {
 			_, _ = fmt.Fprintln(h.config.Output, "  --- I-Cache ---")


### PR DESCRIPTION
Closes #121

## Summary
Implements zero-cycle unconditional branch elimination matching Apple M2's Firestorm behavior where B instructions never issue to execution units.

## Changes
- Add `isEliminableBranch()` helper to detect pure B (not BL) instructions
- Add `EliminatedBranches` stat to track eliminated branches
- Modify fetch stages in all tick methods (single-issue, dual-issue, quad-issue, 6-wide) to eliminate B instructions at fetch time
- Add `EliminatedBranches` to BenchmarkResult and benchmark output

## Key Behavior
- B instructions are detected at fetch and eliminated (PC redirected)
- They never enter the pipeline (IFID register stays empty)
- BL is NOT eliminated (it writes to X30/link register)
- Eliminated branches are tracked separately from retired instructions

## Benchmark Results (branch_taken, no cache)
```
Eliminated Branches:  5
Instructions Retired: 5 (ADD instructions only)
CPI:                  1.800
```

## Testing
- All existing tests pass
- Manual verification with benchmark harness shows 5 branches eliminated

## Design
Follows the design in `docs/BRANCH_ELIMINATION_DESIGN.md` (Phase 1: Basic B Elimination).