### PR TITLE
[Bob] Add SPEC benchmark build scripts

### DIFF
--- a/scripts/arm64-m2sim.cfg
+++ b/scripts/arm64-m2sim.cfg
@@ -1,0 +1,86 @@
+# SPEC CPU 2017 Configuration for M2Sim ARM64 Benchmarks
+# [Bob] Created for M2Sim benchmark validation
+#
+# This config builds ARM64 binaries for use with M2Sim simulator.
+# Binaries are built with minimal optimizations to keep simulation tractable.
+#
+# Usage:
+#   cd $SPEC_ROOT
+#   source shrc
+#   runcpu --config=arm64-m2sim --action=build --tune=base 557.xz_r
+
+# ============================================================================
+# Compiler settings
+# ============================================================================
+
+%define build_ncpus 8
+makeflags = -j%{build_ncpus}
+
+# Label for binaries (appears in exe/*.arm64)
+label = arm64
+
+# Use clang for ARM64 compilation
+# On macOS ARM64 (Apple Silicon), use native clang
+# For cross-compilation, set CC/CXX to cross-compiler paths
+default:
+   CC           = clang
+   CXX          = clang++
+   FC           = flang
+
+# Target ARM64 architecture
+# -target is for cross-compilation; remove if building natively on ARM64
+default:
+   OPTIMIZE     = -O2
+   COPTIMIZE    = 
+   CXXOPTIMIZE  = 
+   FOPTIMIZE    = 
+
+# ARM64 specific flags
+# Using -O2 for reasonable performance while keeping simulation time manageable
+# Avoid -O3 or aggressive optimizations that create complex instruction sequences
+default:
+   EXTRA_CFLAGS    = -mcpu=apple-m2
+   EXTRA_CXXFLAGS  = -mcpu=apple-m2
+   EXTRA_FFLAGS    = 
+
+# Portability settings for various benchmarks
+default:
+   PORTABILITY  = -DSPEC_LP64
+
+# 505.mcf_r portability
+505.mcf_r:
+   CPORTABILITY = -DSPEC_LP64
+
+# 525.x264_r portability  
+525.x264_r:
+   CPORTABILITY = -DSPEC_LP64
+
+# 557.xz_r portability
+557.xz_r:
+   CPORTABILITY = -DSPEC_LP64
+
+# ============================================================================
+# Runtime settings (for reference - M2Sim runs binaries directly)
+# ============================================================================
+
+intrate:
+   copies = 1
+
+fprate:
+   copies = 1
+
+# ============================================================================
+# Monitoring and output
+# ============================================================================
+
+default:
+   output_format = txt
+   teeout        = yes
+
+# ============================================================================
+# Notes
+# ============================================================================
+
+notes_plat_000 = Built for M2Sim Apple M2 simulator
+notes_plat_005 = ARM64 architecture, clang compiler
+notes_plat_010 = Optimized with -O2 for simulation tractability

--- a/scripts/spec-setup.sh
+++ b/scripts/spec-setup.sh
@@ -1,0 +1,123 @@
+#!/bin/bash
+# SPEC CPU 2017 Setup Script for M2Sim
+# [Bob] Created for ARM64 benchmark compilation
+#
+# Prerequisites:
+# - SPEC CPU 2017 ISO/installer at /Users/yifan/Documents/spec
+# - Clang/LLVM for ARM64 cross-compilation (or native ARM64 machine)
+#
+# Usage: ./scripts/spec-setup.sh [install|build|check]
+
+set -e
+
+SPEC_ROOT="${SPEC_ROOT:-/Users/yifan/Documents/spec}"
+M2SIM_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+SPEC_LINK="$M2SIM_ROOT/benchmarks/spec"
+
+# Target benchmarks for M2Sim validation
+BENCHMARKS=(
+    "505.mcf_r"
+    "531.deepsjeng_r"
+    "557.xz_r"
+)
+
+usage() {
+    echo "Usage: $0 [install|build|check|link]"
+    echo ""
+    echo "Commands:"
+    echo "  install  - Run SPEC installer (interactive)"
+    echo "  build    - Build ARM64 binaries for target benchmarks"
+    echo "  check    - Check which binaries are available"
+    echo "  link     - Create symlink from benchmarks/spec to SPEC_ROOT"
+    echo ""
+    echo "Environment:"
+    echo "  SPEC_ROOT - Path to SPEC installation (default: /Users/yifan/Documents/spec)"
+}
+
+check_spec() {
+    if [ ! -f "$SPEC_ROOT/shrc" ]; then
+        echo "ERROR: SPEC not found at $SPEC_ROOT"
+        echo "Set SPEC_ROOT environment variable or install SPEC first"
+        exit 1
+    fi
+}
+
+cmd_link() {
+    if [ -L "$SPEC_LINK" ]; then
+        echo "Symlink already exists: $SPEC_LINK -> $(readlink "$SPEC_LINK")"
+    elif [ -e "$SPEC_LINK" ]; then
+        echo "ERROR: $SPEC_LINK exists but is not a symlink"
+        exit 1
+    else
+        ln -s "$SPEC_ROOT" "$SPEC_LINK"
+        echo "Created symlink: $SPEC_LINK -> $SPEC_ROOT"
+    fi
+}
+
+cmd_install() {
+    if [ ! -f "$SPEC_ROOT/install.sh" ]; then
+        echo "ERROR: SPEC installer not found at $SPEC_ROOT/install.sh"
+        exit 1
+    fi
+    
+    echo "Running SPEC installer..."
+    echo "Note: This is interactive. Accept defaults for most options."
+    cd "$SPEC_ROOT"
+    ./install.sh
+}
+
+cmd_build() {
+    check_spec
+    
+    # Check if config exists
+    CONFIG="$SPEC_ROOT/config/arm64-m2sim.cfg"
+    if [ ! -f "$CONFIG" ]; then
+        echo "Creating ARM64 config file..."
+        cp "$M2SIM_ROOT/scripts/arm64-m2sim.cfg" "$CONFIG"
+    fi
+    
+    cd "$SPEC_ROOT"
+    source shrc
+    
+    echo "Building ARM64 binaries for benchmarks:"
+    for bench in "${BENCHMARKS[@]}"; do
+        echo "  Building $bench..."
+        runcpu --config=arm64-m2sim --action=build --tune=base "$bench" || {
+            echo "WARNING: Failed to build $bench"
+        }
+    done
+    
+    echo ""
+    echo "Build complete. Run '$0 check' to see available binaries."
+}
+
+cmd_check() {
+    check_spec
+    
+    echo "Checking ARM64 binaries:"
+    echo ""
+    
+    for bench in "${BENCHMARKS[@]}"; do
+        # Extract benchmark number and name
+        num=$(echo "$bench" | cut -d. -f1)
+        name=$(echo "$bench" | cut -d. -f2 | sed 's/_r$//')
+        
+        # Look for ARM64 binary
+        binary_path="$SPEC_ROOT/benchspec/CPU/$bench/exe/${name}_r_base.arm64"
+        
+        if [ -f "$binary_path" ]; then
+            echo "  ✅ $bench - $(ls -lh "$binary_path" | awk '{print $5}')"
+        else
+            echo "  ❌ $bench - not built"
+        fi
+    done
+}
+
+# Main
+case "${1:-}" in
+    install) cmd_install ;;
+    build) cmd_build ;;
+    check) cmd_check ;;
+    link) cmd_link ;;
+    *) usage ;;
+esac


### PR DESCRIPTION
## Summary
Adds scripts to set up and build SPEC CPU 2017 benchmarks for ARM64 validation.

## Changes
- `scripts/spec-setup.sh`: Main setup script with commands:
  - `link`: Create symlink to SPEC installation
  - `install`: Run SPEC installer (interactive)
  - `build`: Build ARM64 binaries for target benchmarks (505.mcf_r, 531.deepsjeng_r, 557.xz_r)
  - `check`: Verify which binaries are available

- `scripts/arm64-m2sim.cfg`: SPEC config file for ARM64 compilation
  - Uses clang with -O2 optimization
  - Targets Apple M2 architecture (`-mcpu=apple-m2`)
  - Configured for tractable simulation (avoids aggressive optimizations)

## Usage
```bash
# First time setup
./scripts/spec-setup.sh link
./scripts/spec-setup.sh install  # if not already installed

# Build ARM64 binaries
./scripts/spec-setup.sh build

# Check status
./scripts/spec-setup.sh check
```

## Related
- Issue #107 (SPEC benchmark suite available)
- PR #127 (SPEC benchmark runner infrastructure)