### PR TITLE
[Bob] Implement tournament branch predictor

### DIFF
--- a/cmd/m2sim/timing_test.go
+++ b/cmd/m2sim/timing_test.go
@@ -206,6 +206,6 @@ var _ = Describe("Timing Model Documentation", func() {
 		Expect(config.LoadLatency).To(Equal(uint64(4)))
 		Expect(config.StoreLatency).To(Equal(uint64(1)))
 		Expect(config.SyscallLatency).To(Equal(uint64(1)))
-		Expect(config.BranchMispredictPenalty).To(Equal(uint64(12)))
+		Expect(config.BranchMispredictPenalty).To(Equal(uint64(14)))
 	})
 })

--- a/timing/latency/config.go
+++ b/timing/latency/config.go
@@ -71,7 +71,7 @@ func DefaultTimingConfig() *TimingConfig {
 	return &TimingConfig{
 		ALULatency:              1,
 		BranchLatency:           1,
-		BranchMispredictPenalty: 12,
+		BranchMispredictPenalty: 14,
 		LoadLatency:             4,
 		StoreLatency:            1,
 		MultiplyLatency:         3,

--- a/timing/latency/latency_test.go
+++ b/timing/latency/latency_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Latency", func() {
 
 		It("should have correct branch misprediction penalty", func() {
 			config := table.Config()
-			Expect(config.BranchMispredictPenalty).To(Equal(uint64(12)))
+			Expect(config.BranchMispredictPenalty).To(Equal(uint64(14)))
 		})
 	})
 

--- a/timing/pipeline/branch_predictor.go
+++ b/timing/pipeline/branch_predictor.go
@@ -3,18 +3,26 @@ package pipeline
 // BranchPredictorConfig holds configuration for the branch predictor.
 type BranchPredictorConfig struct {
 	// BHTSize is the number of entries in the Branch History Table.
-	// Must be a power of 2. Default is 1024.
+	// Must be a power of 2. Default is 4096.
 	BHTSize uint32
 	// BTBSize is the number of entries in the Branch Target Buffer.
-	// Must be a power of 2. Default is 256.
+	// Must be a power of 2. Default is 512.
 	BTBSize uint32
+	// GlobalHistoryLength is the length of the global history register.
+	// Default is 12 bits.
+	GlobalHistoryLength uint32
+	// UseTournament enables the tournament predictor (combining bimodal and gshare).
+	// Default is true.
+	UseTournament bool
 }
 
 // DefaultBranchPredictorConfig returns a default configuration.
 func DefaultBranchPredictorConfig() BranchPredictorConfig {
 	return BranchPredictorConfig{
-		BHTSize: 1024,
-		BTBSize: 256,
+		BHTSize:             4096,
+		BTBSize:             512,
+		GlobalHistoryLength: 12,
+		UseTournament:       true,
 	}
 }
 
@@ -30,6 +38,14 @@ type BranchPredictorStats struct {
 	BTBHits uint64
 	// BTBMisses is the number of BTB misses.
 	BTBMisses uint64
+	// BimodalCorrect is correct predictions from the bimodal predictor.
+	BimodalCorrect uint64
+	// GshareCorrect is correct predictions from the gshare predictor.
+	GshareCorrect uint64
+	// TournamentChoseBimodal is how often the tournament chose bimodal.
+	TournamentChoseBimodal uint64
+	// TournamentChoseGshare is how often the tournament chose gshare.
+	TournamentChoseGshare uint64
 }
 
 // Accuracy returns the prediction accuracy as a percentage.
@@ -67,22 +83,38 @@ type Prediction struct {
 	TargetKnown bool
 }
 
-// BranchPredictor implements a 2-bit saturating counter (bimodal) predictor
-// with a Branch Target Buffer (BTB).
+// BranchPredictor implements a tournament predictor combining:
+// 1. Bimodal predictor (2-bit saturating counters indexed by PC)
+// 2. Gshare predictor (2-bit counters indexed by PC XOR global history)
+// 3. Choice predictor (selects between bimodal and gshare)
+//
+// This matches the style of modern high-performance branch predictors.
 type BranchPredictor struct {
-	// Branch History Table (BHT) - 2-bit saturating counters
+	// Bimodal: Branch History Table - 2-bit saturating counters
 	// States: 0=Strongly Not Taken, 1=Weakly Not Taken,
 	//         2=Weakly Taken, 3=Strongly Taken
-	bht []uint8
+	bimodal []uint8
+
+	// Gshare: Pattern History Table - 2-bit saturating counters
+	// Indexed by (PC XOR global_history)
+	gshare []uint8
+
+	// Choice predictor: 2-bit counters that select bimodal vs gshare
+	// 0,1 = favor bimodal, 2,3 = favor gshare
+	choice []uint8
+
+	// Global history register (shift register of branch outcomes)
+	globalHistory uint32
+	historyMask   uint32
 
 	// Branch Target Buffer (BTB)
-	// Maps PC to target address
 	btb      []btbEntry
 	btbValid []bool
 
 	// Configuration
-	bhtSize uint32
-	btbSize uint32
+	bhtSize       uint32
+	btbSize       uint32
+	useTournament bool
 
 	// Statistics
 	stats BranchPredictorStats
@@ -98,35 +130,71 @@ type btbEntry struct {
 func NewBranchPredictor(config BranchPredictorConfig) *BranchPredictor {
 	bhtSize := config.BHTSize
 	btbSize := config.BTBSize
+	historyLen := config.GlobalHistoryLength
 
 	// Default sizes if not specified
 	if bhtSize == 0 {
-		bhtSize = 1024
+		bhtSize = 4096
 	}
 	if btbSize == 0 {
-		btbSize = 256
+		btbSize = 512
 	}
+	if historyLen == 0 {
+		historyLen = 12
+	}
+
+	historyMask := uint32((1 << historyLen) - 1)
 
 	bp := &BranchPredictor{
-		bht:      make([]uint8, bhtSize),
-		btb:      make([]btbEntry, btbSize),
-		btbValid: make([]bool, btbSize),
-		bhtSize:  bhtSize,
-		btbSize:  btbSize,
+		bimodal:       make([]uint8, bhtSize),
+		gshare:        make([]uint8, bhtSize),
+		choice:        make([]uint8, bhtSize),
+		btb:           make([]btbEntry, btbSize),
+		btbValid:      make([]bool, btbSize),
+		bhtSize:       bhtSize,
+		btbSize:       btbSize,
+		globalHistory: 0,
+		historyMask:   historyMask,
+		useTournament: config.UseTournament,
 	}
 
-	// Initialize BHT with weakly taken (2) - biased towards taken
-	for i := range bp.bht {
-		bp.bht[i] = 2
+	// Initialize bimodal BHT with weakly taken (2) - biased towards taken
+	for i := range bp.bimodal {
+		bp.bimodal[i] = 2
+	}
+
+	// Initialize gshare PHT with weakly taken (2)
+	for i := range bp.gshare {
+		bp.gshare[i] = 2
+	}
+
+	// Initialize choice with weakly favor gshare (2)
+	// Gshare tends to work better for most workloads
+	for i := range bp.choice {
+		bp.choice[i] = 2
 	}
 
 	return bp
 }
 
-// bhtIndex computes the BHT index for a given PC.
-func (bp *BranchPredictor) bhtIndex(pc uint64) uint32 {
+// bimodalIndex computes the bimodal predictor index for a given PC.
+func (bp *BranchPredictor) bimodalIndex(pc uint64) uint32 {
 	// Use lower bits of PC (excluding alignment bits)
 	return uint32((pc >> 2) & uint64(bp.bhtSize-1))
+}
+
+// gshareIndex computes the gshare predictor index (PC XOR global history).
+func (bp *BranchPredictor) gshareIndex(pc uint64) uint32 {
+	pcBits := uint32((pc >> 2) & uint64(bp.bhtSize-1))
+	// XOR PC with global history (extended to match index width)
+	history := bp.globalHistory & bp.historyMask
+	return (pcBits ^ history) & (bp.bhtSize - 1)
+}
+
+// choiceIndex computes the choice predictor index.
+func (bp *BranchPredictor) choiceIndex(pc uint64) uint32 {
+	// Use same indexing as bimodal for simplicity
+	return bp.bimodalIndex(pc)
 }
 
 // btbIndex computes the BTB index for a given PC.
@@ -139,10 +207,32 @@ func (bp *BranchPredictor) btbIndex(pc uint64) uint32 {
 func (bp *BranchPredictor) Predict(pc uint64) Prediction {
 	pred := Prediction{}
 
-	// Look up BHT for taken/not-taken prediction
-	bhtIdx := bp.bhtIndex(pc)
-	counter := bp.bht[bhtIdx]
-	pred.Taken = counter >= 2 // Taken if counter is 2 or 3
+	// Get predictions from both predictors
+	bimodalIdx := bp.bimodalIndex(pc)
+	bimodalCounter := bp.bimodal[bimodalIdx]
+	bimodalTaken := bimodalCounter >= 2
+
+	gshareIdx := bp.gshareIndex(pc)
+	gshareCounter := bp.gshare[gshareIdx]
+	gshareTaken := gshareCounter >= 2
+
+	if bp.useTournament {
+		// Use choice predictor to select between bimodal and gshare
+		choiceIdx := bp.choiceIndex(pc)
+		choiceCounter := bp.choice[choiceIdx]
+		useGshare := choiceCounter >= 2
+
+		if useGshare {
+			pred.Taken = gshareTaken
+			bp.stats.TournamentChoseGshare++
+		} else {
+			pred.Taken = bimodalTaken
+			bp.stats.TournamentChoseBimodal++
+		}
+	} else {
+		// Just use bimodal (legacy mode)
+		pred.Taken = bimodalTaken
+	}
 
 	// Look up BTB for target address
 	btbIdx := bp.btbIndex(pc)
@@ -160,28 +250,87 @@ func (bp *BranchPredictor) Predict(pc uint64) Prediction {
 
 // Update updates the predictor with the actual branch outcome.
 func (bp *BranchPredictor) Update(pc uint64, taken bool, target uint64) {
-	// Update BHT
-	bhtIdx := bp.bhtIndex(pc)
-	counter := bp.bht[bhtIdx]
+	// Get indices
+	bimodalIdx := bp.bimodalIndex(pc)
+	gshareIdx := bp.gshareIndex(pc)
+	choiceIdx := bp.choiceIndex(pc)
 
-	// Check if prediction was correct
-	predicted := counter >= 2
-	if predicted == taken {
+	// Get current predictions
+	bimodalCounter := bp.bimodal[bimodalIdx]
+	bimodalPredicted := bimodalCounter >= 2
+	bimodalCorrect := bimodalPredicted == taken
+
+	gshareCounter := bp.gshare[gshareIdx]
+	gsharePredicted := gshareCounter >= 2
+	gshareCorrect := gsharePredicted == taken
+
+	// Track which predictor was correct
+	if bimodalCorrect {
+		bp.stats.BimodalCorrect++
+	}
+	if gshareCorrect {
+		bp.stats.GshareCorrect++
+	}
+
+	// Determine if final prediction was correct
+	var finalPrediction bool
+	if bp.useTournament {
+		choiceCounter := bp.choice[choiceIdx]
+		useGshare := choiceCounter >= 2
+		if useGshare {
+			finalPrediction = gsharePredicted
+		} else {
+			finalPrediction = bimodalPredicted
+		}
+	} else {
+		finalPrediction = bimodalPredicted
+	}
+
+	if finalPrediction == taken {
 		bp.stats.Correct++
 	} else {
 		bp.stats.Mispredictions++
 	}
 
-	// Update 2-bit saturating counter
+	// Update bimodal 2-bit saturating counter
 	if taken {
-		if counter < 3 {
-			bp.bht[bhtIdx] = counter + 1
+		if bp.bimodal[bimodalIdx] < 3 {
+			bp.bimodal[bimodalIdx]++
 		}
 	} else {
-		if counter > 0 {
-			bp.bht[bhtIdx] = counter - 1
+		if bp.bimodal[bimodalIdx] > 0 {
+			bp.bimodal[bimodalIdx]--
 		}
 	}
+
+	// Update gshare 2-bit saturating counter
+	if taken {
+		if bp.gshare[gshareIdx] < 3 {
+			bp.gshare[gshareIdx]++
+		}
+	} else {
+		if bp.gshare[gshareIdx] > 0 {
+			bp.gshare[gshareIdx]--
+		}
+	}
+
+	// Update choice predictor only when predictors disagree
+	if bp.useTournament && bimodalCorrect != gshareCorrect {
+		if gshareCorrect {
+			// Gshare was correct, bimodal was wrong -> favor gshare more
+			if bp.choice[choiceIdx] < 3 {
+				bp.choice[choiceIdx]++
+			}
+		} else {
+			// Bimodal was correct, gshare was wrong -> favor bimodal more
+			if bp.choice[choiceIdx] > 0 {
+				bp.choice[choiceIdx]--
+			}
+		}
+	}
+
+	// Update global history (shift in the branch outcome)
+	bp.globalHistory = ((bp.globalHistory << 1) | boolToUint32(taken)) & bp.historyMask
 
 	// Update BTB if branch was taken
 	if taken {
@@ -194,6 +343,14 @@ func (bp *BranchPredictor) Update(pc uint64, taken bool, target uint64) {
 	}
 }
 
+// boolToUint32 converts a bool to 0 or 1.
+func boolToUint32(b bool) uint32 {
+	if b {
+		return 1
+	}
+	return 0
+}
+
 // Stats returns the branch predictor statistics.
 func (bp *BranchPredictor) Stats() BranchPredictorStats {
 	return bp.stats
@@ -201,10 +358,23 @@ func (bp *BranchPredictor) Stats() BranchPredictorStats {
 
 // Reset clears all predictor state and statistics.
 func (bp *BranchPredictor) Reset() {
-	// Reset BHT to weakly taken
-	for i := range bp.bht {
-		bp.bht[i] = 2
+	// Reset bimodal to weakly taken
+	for i := range bp.bimodal {
+		bp.bimodal[i] = 2
 	}
+
+	// Reset gshare to weakly taken
+	for i := range bp.gshare {
+		bp.gshare[i] = 2
+	}
+
+	// Reset choice to weakly favor gshare
+	for i := range bp.choice {
+		bp.choice[i] = 2
+	}
+
+	// Reset global history
+	bp.globalHistory = 0
 
 	// Clear BTB
 	for i := range bp.btbValid {

--- a/timing/pipeline/pipeline_test.go
+++ b/timing/pipeline/pipeline_test.go
@@ -481,7 +481,7 @@ var _ = Describe("Pipeline Integration", func() {
 			config := &latency.TimingConfig{
 				ALULatency:              3,
 				BranchLatency:           1,
-				BranchMispredictPenalty: 12,
+				BranchMispredictPenalty: 14,
 				LoadLatency:             4,
 				StoreLatency:            1,
 				MultiplyLatency:         3,
@@ -545,7 +545,7 @@ var _ = Describe("Pipeline Integration", func() {
 			config := &latency.TimingConfig{
 				ALULatency:              1,
 				BranchLatency:           1,
-				BranchMispredictPenalty: 12,
+				BranchMispredictPenalty: 14,
 				LoadLatency:             4, // 4-cycle load
 				StoreLatency:            1,
 				MultiplyLatency:         3,


### PR DESCRIPTION
Closes #135

## Summary
Upgraded the branch predictor from simple bimodal to a tournament predictor for improved accuracy.

## Changes
- **Tournament predictor**: Combines bimodal and gshare predictors with a choice predictor
- **Gshare component**: Uses PC XOR global history for pattern recognition
- **Increased table sizes**: BHT 4096 entries, BTB 512 entries
- **12-bit global history**: Captures longer branch correlation patterns
- **Updated misprediction penalty**: 12 → 14 cycles to match M2 Avalanche core

## Technical Details
The tournament predictor dynamically selects between:
1. **Bimodal**: Good for branches with stable direction
2. **Gshare**: Better for branches correlated with recent history

The choice predictor adapts based on which component makes better predictions.

## Testing
- All 163 pipeline tests pass
- All 35 latency tests pass
- All tests pass across the codebase