### PR TITLE
[Bob] Tune memory latency parameters for M2 accuracy

### DIFF
--- a/timing/cache/cache.go
+++ b/timing/cache/cache.go
@@ -50,17 +50,18 @@ func DefaultL1DConfig() Config {
 
 // DefaultL2Config returns default configuration for unified L2 cache.
 // Based on Apple M2 specifications:
-// - 16MB shared L2 (per-cluster)
+// - 24MB shared L2 (entire chip)
 // - 16-way set associative
 // - 128B cache line
 // - ~12-14 cycle latency
+// - Unified memory architecture has lower latency than typical DRAM
 func DefaultL2Config() Config {
 	return Config{
-		Size:          16 * 1024 * 1024, // 16MB
+		Size:          24 * 1024 * 1024, // 24MB (M2 spec)
 		Associativity: 16,               // 16-way
 		BlockSize:     128,              // 128B cache line
 		HitLatency:    12,               // ~12 cycles
-		MissLatency:   200,              // ~200 cycles to main memory
+		MissLatency:   150,              // ~150 cycles (unified memory is faster than typical DRAM)
 	}
 }
 
@@ -72,7 +73,7 @@ func DefaultL2PerCoreConfig() Config {
 		Associativity: 8,          // 8-way
 		BlockSize:     128,        // 128B cache line
 		HitLatency:    12,         // ~12 cycles
-		MissLatency:   200,        // ~200 cycles to main memory
+		MissLatency:   150,        // ~150 cycles (unified memory)
 	}
 }
 

--- a/timing/cache/cache_test.go
+++ b/timing/cache/cache_test.go
@@ -192,11 +192,11 @@ var _ = Describe("Cache", func() {
 
 		It("should create L2 config", func() {
 			config := cache.DefaultL2Config()
-			Expect(config.Size).To(Equal(16 * 1024 * 1024))
+			Expect(config.Size).To(Equal(24 * 1024 * 1024)) // M2 has 24MB shared L2
 			Expect(config.Associativity).To(Equal(16))
 			Expect(config.BlockSize).To(Equal(128))
 			Expect(config.HitLatency).To(Equal(uint64(12)))
-			Expect(config.MissLatency).To(Equal(uint64(200)))
+			Expect(config.MissLatency).To(Equal(uint64(150))) // Unified memory is faster
 		})
 
 		It("should create L2 per-core config", func() {


### PR DESCRIPTION
## Summary
Tuned memory hierarchy parameters to better match Apple M2 specifications per Eric's research in #136.

## Changes
- **L2 cache size:** 16MB → 24MB (matches M2 spec)
- **Memory latency:** 200 cycles → 150 cycles (unified memory architecture is faster than typical DRAM)

## Rationale
- Apple M2 has 24MB shared L2, not 16MB per-cluster
- M2's unified memory architecture provides lower latency than traditional DRAM
- These changes should improve accuracy for memory-bound workloads

## Testing
- All cache tests updated and passing
- All other tests passing

Closes #136