### PR TITLE
[Bob] CoreMark integration phase 1 - M2 baseline

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -14,3 +14,4 @@ benchmarks/spec
 
 # OS
 .DS_Store
+benchmarks/coremark/

--- a/benchmarks/baselines/coremark_m2.csv
+++ b/benchmarks/baselines/coremark_m2.csv
@@ -1,0 +1,8 @@
+# CoreMark Baseline - Apple M2
+# Date: 2026-02-04
+# System: macOS ARM64 (Apple M2)
+# Compiler: Apple LLVM 17.0.0 (clang-1700.6.3.2)
+# Flags: -O2 -DPERFORMANCE_RUN=1
+# Iterations: 600000
+benchmark,iterations_per_sec,total_time_sec,total_ticks,crc_final
+coremark,35120.58,17.084,17084,0xa14c

--- a/docs/alternative-benchmarks.md
+++ b/docs/alternative-benchmarks.md
@@ -81,3 +81,19 @@ cd embench-iot
 **Next:** Evaluate Embench-IoT for additional workload diversity.
 
 **Long-term:** Complete SPEC setup once human unblocks Gatekeeper issue.
+
+## M2Sim Integration Note
+
+**Important:** M2Sim requires ELF binaries, not Mach-O.
+
+To run CoreMark in M2Sim:
+1. Install aarch64-elf-gcc: `brew install aarch64-elf-gcc`
+2. Cross-compile CoreMark for ELF target
+3. Run through M2Sim timing mode
+
+**Baseline captured:** `benchmarks/baselines/coremark_m2.csv`
+- Real M2: 35,120.58 iterations/sec (600K iterations in 17s)
+- Compiler: Apple LLVM 17.0.0
+- Flags: -O2
+
+See issue #147 for implementation status.


### PR DESCRIPTION
# CoreMark Integration - Phase 1

Addresses #147

## What
- Built and ran CoreMark on real M2 hardware
- Captured baseline: **35,120.58 iterations/sec**
- Documented cross-compilation requirement for M2Sim

## Changes
- `benchmarks/baselines/coremark_m2.csv` - Real M2 timing baseline
- `docs/alternative-benchmarks.md` - Added M2Sim integration notes
- `.gitignore` - Exclude cloned coremark directory

## Next Steps (Phase 2)
1. Install `aarch64-elf-gcc` cross-compiler
2. Cross-compile CoreMark as ELF binary
3. Run through M2Sim timing mode
4. Compare simulated vs real timing

## Test Results
- CoreMark builds and validates correctly on M2
- 600,000 iterations completed in 17.084 seconds
- CRC validation passed (0xa14c)