### PR TITLE
[Bob] Accuracy analysis and documentation (#115)

### DIFF
--- a/benchmarks/accuracy_test.go
+++ b/benchmarks/accuracy_test.go
@@ -263,10 +263,10 @@ func TestAccuracyArithmetic(t *testing.T) {
 	errorPct := calculateError(simCPI, realCPI)
 
 	t.Logf("Arithmetic Throughput Accuracy:")
-	t.Logf("  Simulator: %.3f CPI (single-issue model)", simCPI)
-	t.Logf("  M2 Real:   %.3f CPI (superscalar - ~4 ADDs/cycle)", realCPI)
+	t.Logf("  Simulator: %.3f CPI (6-wide superscalar)", simCPI)
+	t.Logf("  M2 Real:   %.3f CPI (8+ ALUs with fusion)", realCPI)
 	t.Logf("  Error:     %.1f%%", errorPct)
-	t.Logf("  Note: M2Sim is single-issue, M2 is superscalar. Large gap expected.")
+	t.Logf("  Note: M2 is wider and has instruction fusion. See docs/accuracy-analysis.md")
 }
 
 // TestAccuracyBranch tests branch handling accuracy.

--- a/docs/accuracy-analysis.md
+++ b/docs/accuracy-analysis.md
@@ -1,0 +1,100 @@
+# M2Sim Accuracy Analysis
+
+*Analysis by Bob — 2026-02-04*
+
+## Current Status
+
+| Benchmark | Sim CPI | M2 CPI | Error | Explanation |
+|-----------|---------|--------|-------|-------------|
+| arithmetic_sequential | 0.400 | 0.268 | 49.3% | Pipeline fill overhead |
+| dependency_chain | 1.200 | 1.009 | 18.9% | Forwarding latency delta |
+| branch_taken | 1.800 | 1.190 | 51.3% | Branch elimination overhead |
+
+**Average Error: 39.8%**
+
+## Root Cause Analysis
+
+### 1. Arithmetic Sequential (49.3% error)
+
+**What we observed:**
+- 20 independent ADD instructions
+- 8 cycles total on 6-wide superscalar
+- CPI = 0.400
+
+**Expected (ideal 6-wide):**
+- Steady state: ceil(20/6) = 4 cycles
+- With pipeline fill (~4 cycles): 8 cycles total
+- This matches! The simulator is correct for our model.
+
+**Why M2 is faster (CPI 0.268):**
+- M2 has 8+ integer ALUs (not just 6)
+- Micro-op fusion combines operations
+- Out-of-order execution hides fill latency
+- Register renaming enables more parallelism
+
+**Potential fixes:**
+1. Implement 8-wide superscalar
+2. Add instruction fusion for common patterns
+3. Model out-of-order execution (complex)
+
+### 2. Branch Taken (51.3% error)
+
+**What we observed:**
+- 5 B instructions (eliminated) + 5 ADDs + 1 SVC
+- 9 cycles total
+- CPI = 1.800 (counting only 5 ADDs)
+
+**Why the gap:**
+- Branch elimination removes ALU cycles but not fetch/decode overhead
+- Each branch causes a control flow redirect
+- Sequential code between branches can't be speculatively fetched
+
+**Why M2 is faster (CPI 1.190):**
+- Deeper speculation across multiple branches
+- Branch target prediction allows prefetching
+- Better instruction buffer management
+
+**Potential fixes:**
+1. Improve fetch to not stall on eliminated branches
+2. Add speculative fetch-ahead for branch targets
+3. Model branch target buffer (BTB)
+
+### 3. Dependency Chain (18.9% error)
+
+**What we observed:**
+- 20 dependent ADD instructions
+- CPI = 1.200 (1 cycle per instruction + forwarding)
+
+**Why the gap:**
+- M2 achieves CPI 1.009 — nearly 1 cycle per dependent op
+- Our model has ~0.2 CPI overhead per instruction
+
+**Potential fixes:**
+1. Reduce forwarding latency
+2. Model M2's precise pipeline timing
+
+## Recommended Next Steps
+
+### Phase 1: Low-hanging fruit (effort: low)
+- [ ] Update test log messages to reflect 6-wide reality
+- [ ] Document current accuracy gaps
+- [ ] Add verbose stats output to benchmarks
+
+### Phase 2: Architecture improvements (effort: medium)
+- [ ] Increase superscalar width to 8-wide
+- [ ] Improve branch elimination to not stall fetch
+- [ ] Fine-tune forwarding latency
+
+### Phase 3: Major enhancements (effort: high)
+- [ ] Model out-of-order execution
+- [ ] Add branch target buffer (BTB)
+- [ ] Implement instruction fusion
+
+## Conclusion
+
+The simulator is **functionally correct** but has accuracy gaps due to:
+1. M2 being wider than our 6-wide model
+2. Missing microarchitectural features (OoO, BTB, fusion)
+3. Pipeline fill overhead on short benchmarks
+
+For intermediate benchmarks (100ms+ runtime), the pipeline fill overhead will be negligible, and we should see better accuracy.


### PR DESCRIPTION
## Summary
Adds root cause analysis for microbenchmark accuracy gaps.

## Changes
- New `docs/accuracy-analysis.md` with detailed analysis of:
  - arithmetic_sequential (49.3% error): Pipeline fill overhead, M2 is wider
  - branch_taken (51.3% error): Branch elimination doesn't hide fetch overhead
  - dependency_chain (18.9% error): Forwarding latency delta
- Updated test log messages to reflect 6-wide superscalar reality

## Key Findings
1. The simulator is **functionally correct** for our 6-wide model
2. M2 has 8+ integer ALUs (wider than our model)
3. M2 uses instruction fusion and OoO execution

## Recommended Next Steps
1. Consider 8-wide superscalar
2. Improve branch elimination to not stall fetch
3. For intermediate benchmarks, pipeline fill overhead will be negligible

Relates to #115