### PR TITLE
[Bob] Add BRK instruction support

### DIFF
--- a/emu/emulator.go
+++ b/emu/emulator.go
@@ -216,6 +216,15 @@ func (e *Emulator) execute(inst *insts.Instruction) StepResult {
 		return e.executeSVC()
 	}
 
+	// Handle BRK (breakpoint/trap) - indicates an error condition or assertion
+	if inst.Op == insts.OpBRK {
+		return StepResult{
+			Exited:   true,
+			ExitCode: -1, // Trap exit code
+			Err:      fmt.Errorf("BRK trap #0x%X at PC=0x%X", inst.Imm, e.regFile.PC),
+		}
+	}
+
 	// Execute based on instruction type
 	switch inst.Format {
 	case insts.FormatDPImm:

--- a/insts/decoder_test.go
+++ b/insts/decoder_test.go
@@ -547,6 +547,27 @@ var _ = Describe("Decoder", func() {
 			Expect(inst.Format).To(Equal(insts.FormatException))
 			Expect(inst.Imm).To(Equal(uint64(0xFFFF)))
 		})
+
+		// BRK #0x3e8        -> 0xD4207D00
+		// Encoding: 11010100 001 | imm16=0x3e8 | 00000
+		// This is the BRK instruction that CoreMark uses for assertions
+		It("should decode BRK #0x3e8 (from CoreMark)", func() {
+			inst := decoder.Decode(0xD4207D00)
+
+			Expect(inst.Op).To(Equal(insts.OpBRK))
+			Expect(inst.Format).To(Equal(insts.FormatException))
+			Expect(inst.Imm).To(Equal(uint64(0x3e8)))
+		})
+
+		// BRK #0            -> 0xD4200000
+		// Encoding: 11010100 001 | imm16=0 | 00000
+		It("should decode BRK #0", func() {
+			inst := decoder.Decode(0xD4200000)
+
+			Expect(inst.Op).To(Equal(insts.OpBRK))
+			Expect(inst.Format).To(Equal(insts.FormatException))
+			Expect(inst.Imm).To(Equal(uint64(0)))
+		})
 	})
 
 	Describe("Unknown Instructions", func() {


### PR DESCRIPTION
## Summary
Implement BRK (breakpoint/trap) instruction decoding and handling.

## Changes
- Add OpBRK opcode
- Update isException to match BRK encoding pattern
- Update decodeException to distinguish SVC vs BRK
- Handle BRK in emulator (exits with -1, reports trap info)
- Add tests for BRK decoding

## Context
BRK is used by CoreMark and other programs for assertion failures. This allows the simulator to properly identify when a program hits an assertion rather than reporting 'unknown instruction'.

## Testing
- All existing tests pass
- Added 2 new BRK decoding tests
- Verified CoreMark now reports BRK trap instead of unknown instruction

Part of #172 - CoreMark debugging