### PR TITLE
[Cathy] Add pipeline stats coverage tests

### DIFF
--- a/timing/pipeline/pipeline_test.go
+++ b/timing/pipeline/pipeline_test.go
@@ -691,3 +691,54 @@ var _ = Describe("Pipeline Integration", func() {
 		})
 	})
 })
+
+// Tests for Stats and rate methods - added by Cathy for coverage
+var _ = Describe("Pipeline Stats Methods", func() {
+	var (
+		regFile *emu.RegFile
+		memory  *emu.Memory
+		pipe    *pipeline.Pipeline
+	)
+
+	BeforeEach(func() {
+		regFile = &emu.RegFile{}
+		memory = emu.NewMemory()
+		pipe = pipeline.NewPipeline(regFile, memory, pipeline.WithSextupleIssue())
+	})
+
+	Describe("Statistics.CPI", func() {
+		It("should return zero for zero instructions", func() {
+			stats := pipe.Stats()
+			cpi := stats.CPI()
+			Expect(cpi).To(Equal(0.0))
+		})
+	})
+
+	Describe("ExitCode", func() {
+		It("should return zero initially", func() {
+			code := pipe.ExitCode()
+			Expect(code).To(Equal(int64(0)))
+		})
+	})
+
+	Describe("BranchPredictorStats", func() {
+		It("should return branch predictor statistics", func() {
+			stats := pipe.BranchPredictorStats()
+			Expect(stats.Predictions).To(BeNumerically(">=", 0))
+		})
+
+		It("should calculate misprediction rate", func() {
+			stats := pipe.BranchPredictorStats()
+			rate := stats.MispredictionRate()
+			Expect(rate).To(BeNumerically(">=", 0.0))
+			Expect(rate).To(BeNumerically("<=", 1.0))
+		})
+
+		It("should calculate BTB hit rate", func() {
+			stats := pipe.BranchPredictorStats()
+			rate := stats.BTBHitRate()
+			Expect(rate).To(BeNumerically(">=", 0.0))
+			Expect(rate).To(BeNumerically("<=", 1.0))
+		})
+	})
+})


### PR DESCRIPTION
## Summary

Add tests for previously uncovered pipeline statistics methods.

## Test Coverage

- **Statistics.CPI()** - Test CPI calculation returns 0 for zero instructions
- **Pipeline.ExitCode()** - Test initial exit code is 0
- **BranchPredictorStats** - Test stats struct methods:
  - MispredictionRate()
  - BTBHitRate()

## Coverage Improvement

Pipeline package coverage: 69.7% → 70.1%

Per Grace guidance: Cathy should write pipeline tests proactively instead of waiting for Bob's PRs.