### PR TITLE
[Bob] Fix Embench benchmark exit code

### DIFF
--- a/benchmarks/aha-mont64-m2sim/startup.S
+++ b/benchmarks/aha-mont64-m2sim/startup.S
@@ -31,9 +31,10 @@ _start:
     add x1, x1, :lo12:result
     str w0, [x1]
     
-    /* Halt with success */
-    mov x0, #0
-    brk #0
+    /* Exit via syscall with code 0 */
+    mov x8, #93     /* exit syscall number */
+    mov x0, #0      /* exit code 0 = success */
+    svc #0          /* syscall */
 
 .section .data
 .global result

--- a/benchmarks/crc32-m2sim/startup.S
+++ b/benchmarks/crc32-m2sim/startup.S
@@ -1,4 +1,4 @@
-/* M2Sim bare-metal startup for aha-mont64 */
+/* M2Sim bare-metal startup for crc32 */
 .section .text.startup
 .global _start
 .type _start, %function
@@ -31,9 +31,10 @@ _start:
     add x1, x1, :lo12:result
     str w0, [x1]
     
-    /* Halt with success */
-    mov x0, #0
-    brk #0
+    /* Exit via syscall with code 0 */
+    mov x8, #93     /* exit syscall number */
+    mov x0, #0      /* exit code 0 = success */
+    svc #0          /* syscall */
 
 .section .data
 .global result

--- a/benchmarks/matmult-int-m2sim/startup.S
+++ b/benchmarks/matmult-int-m2sim/startup.S
@@ -1,4 +1,4 @@
-/* M2Sim bare-metal startup for aha-mont64 */
+/* M2Sim bare-metal startup for matmult-int */
 .section .text.startup
 .global _start
 .type _start, %function
@@ -31,9 +31,10 @@ _start:
     add x1, x1, :lo12:result
     str w0, [x1]
     
-    /* Halt with success */
-    mov x0, #0
-    brk #0
+    /* Exit via syscall with code 0 */
+    mov x8, #93     /* exit syscall number */
+    mov x0, #0      /* exit code 0 = success */
+    svc #0          /* syscall */
 
 .section .data
 .global result


### PR DESCRIPTION
## Summary
Fix all Embench benchmarks to exit with code 0 instead of -1.

## Problem
Benchmarks used `brk #0` (trap) for termination, which caused exit code -1.

## Solution
Changed startup.S files to use proper exit syscall:
```asm
mov x8, #93   /* exit syscall */
mov x0, #0    /* exit code 0 */
svc #0        /* syscall */
```

## Results
| Benchmark | Instructions | Exit Code |
|-----------|-------------|-----------|
| aha-mont64 | 1,880,725 | 0 ✓ |
| crc32 | 1,569,646 | 0 ✓ |
| matmult-int | 3,849,381 | 0 ✓ |

## Notes
After pulling, rebuild benchmarks with `./build.sh` in each benchmark directory.

🎉 All Embench benchmarks now complete successfully!