### PR TITLE
[Bob] Fix branch predictor default to match M2 behavior

### DIFF
--- a/timing/pipeline/branch_predictor.go
+++ b/timing/pipeline/branch_predictor.go
@@ -158,14 +158,15 @@ func NewBranchPredictor(config BranchPredictorConfig) *BranchPredictor {
 		useTournament: config.UseTournament,
 	}
 
-	// Initialize bimodal BHT with weakly taken (2) - biased towards taken
+	// Initialize bimodal BHT with weakly not-taken (1) - matches M2 behavior
+	// M2 Avalanche cores default to "not-taken" for cold branches (see #199)
 	for i := range bp.bimodal {
-		bp.bimodal[i] = 2
+		bp.bimodal[i] = 1
 	}
 
-	// Initialize gshare PHT with weakly taken (2)
+	// Initialize gshare PHT with weakly not-taken (1) - matches M2 behavior
 	for i := range bp.gshare {
-		bp.gshare[i] = 2
+		bp.gshare[i] = 1
 	}
 
 	// Initialize choice with weakly favor gshare (2)
@@ -358,14 +359,14 @@ func (bp *BranchPredictor) Stats() BranchPredictorStats {
 
 // Reset clears all predictor state and statistics.
 func (bp *BranchPredictor) Reset() {
-	// Reset bimodal to weakly taken
+	// Reset bimodal to weakly not-taken (matches M2 behavior)
 	for i := range bp.bimodal {
-		bp.bimodal[i] = 2
+		bp.bimodal[i] = 1
 	}
 
-	// Reset gshare to weakly taken
+	// Reset gshare to weakly not-taken (matches M2 behavior)
 	for i := range bp.gshare {
-		bp.gshare[i] = 2
+		bp.gshare[i] = 1
 	}
 
 	// Reset choice to weakly favor gshare


### PR DESCRIPTION
## Summary

Changes branch predictor initial counter value from 2 (weakly taken) to 1 (weakly not-taken) to match M2 Avalanche core behavior.

## Changes

- `NewBranchPredictor()`: Initialize bimodal and gshare counters to 1 (weakly not-taken)
- `Reset()`: Use same not-taken default
- Updated tests to match new expected behavior

## Context

From Eric's research in `docs/m2-microarchitecture.md`:
> First branch at new address defaults to predict 'not-taken'

Our simulator was initializing to 'weakly taken' (counter=2), causing mispredictions on cold branches that M2 would predict correctly.

## Impact

This should help reduce the 51.3% error on the branch benchmark by better matching M2's cold branch behavior.

Closes #199