### PR TITLE
[Cathy] Remove dead code: DetectLoadUseHazard

### DIFF
--- a/timing/pipeline/hazard.go
+++ b/timing/pipeline/hazard.go
@@ -106,24 +106,6 @@ func (h *HazardUnit) detectForwardForReg(
 	return ForwardNone
 }
 
-// DetectLoadUseHazard detects load-use hazards where a load instruction
-// is immediately followed by an instruction using the loaded value.
-// This requires a stall because the value isn't available until MEM stage.
-func (h *HazardUnit) DetectLoadUseHazard(idex *IDEXRegister, nextRn, nextRm uint8) bool {
-	// Only load instructions cause load-use hazards
-	if !idex.Valid || !idex.MemRead {
-		return false
-	}
-
-	// XZR doesn't cause hazards
-	if idex.Rd == 31 {
-		return false
-	}
-
-	// Check if next instruction uses the load destination
-	return idex.Rd == nextRn || idex.Rd == nextRm
-}
-
 // DetectLoadUseHazardDecoded detects load-use hazard using decoded register info.
 // loadRd is the destination of the load instruction in ID/EX.
 // nextRn, nextRm are the source registers of the next instruction.


### PR DESCRIPTION
## Summary

Removes the unused `DetectLoadUseHazard` function from `hazard.go`.

## Background

This function was superseded by `DetectLoadUseHazardDecoded`, which is used at all 4 call sites in `pipeline.go`:
- Line 402
- Line 1030
- Line 1743
- Line 2742

The original function was never called and constitutes dead code.

## Changes

- Removed `DetectLoadUseHazard` function (18 lines)
- No functional impact — unused code removal only

## Testing

- All 205 pipeline tests pass
- `go build ./...` succeeds

## Related

- Part of ongoing code quality improvements