### PR TITLE
[Bob] Wire conditional benchmark to accuracy_test.go

### DIFF
--- a/benchmarks/accuracy_test.go
+++ b/benchmarks/accuracy_test.go
@@ -68,10 +68,11 @@ type AccuracySummary struct {
 }
 
 // benchmarkMapping maps simulator benchmark names to baseline names.
+// Uses branch_taken_conditional to match native benchmark pattern (CMP + B.GE).
 var benchmarkMapping = map[string]string{
-	"arithmetic_sequential": "arithmetic",
-	"dependency_chain":      "dependency",
-	"branch_taken":          "branch",
+	"arithmetic_sequential":    "arithmetic",
+	"dependency_chain":         "dependency",
+	"branch_taken_conditional": "branch",
 }
 
 // loadBaseline loads the M2 baseline data from the native directory.
@@ -269,7 +270,8 @@ func TestAccuracyArithmetic(t *testing.T) {
 	t.Logf("  Note: M2 is wider and has instruction fusion. See docs/accuracy-analysis.md")
 }
 
-// TestAccuracyBranch tests branch handling accuracy.
+// TestAccuracyBranch tests branch handling accuracy using conditional branches.
+// Uses branchTakenConditional to match native benchmark pattern (CMP + B.GE).
 func TestAccuracyBranch(t *testing.T) {
 	baseline := loadBaseline(t)
 	baselineEntry := findBaseline(baseline, "branch")
@@ -281,7 +283,7 @@ func TestAccuracyBranch(t *testing.T) {
 	config.EnableICache = false
 	config.EnableDCache = false
 	harness := NewHarness(config)
-	harness.AddBenchmark(branchTaken())
+	harness.AddBenchmark(branchTakenConditional())
 	results := harness.RunAll()
 
 	if len(results) != 1 {


### PR DESCRIPTION
Closes #207

## Changes

- Update `benchmarkMapping` to use `branch_taken_conditional` instead of `branch_taken`
- Update `TestAccuracyBranch` to use `branchTakenConditional()`
- Now uses the same benchmark pattern as native M2 (CMP + B.GE)

## Test Results

Before (using unconditional B):
- branch_taken: 51.3% error
- Average: 39.8%

After (using conditional B.GE):
- branch_taken_conditional: 62.5% error
- Average: 43.5%

Note: Error is higher with conditional benchmarks, which accurately reflects the simulator's current state. This is expected — now measuring against the correct benchmark pattern.