### PR TITLE
[Bob] Implement CMP+B.cond macro-op fusion

### DIFF
--- a/timing/pipeline/superscalar.go
+++ b/timing/pipeline/superscalar.go
@@ -1007,6 +1007,9 @@ func (r *SecondaryMEMWBRegister) GetALUResult() uint64 { return r.ALUResult }
 // GetMemData returns the data loaded from memory.
 func (r *SecondaryMEMWBRegister) GetMemData() uint64 { return r.MemData }
 
+// GetIsFused returns false as fusion only occurs in slot 0.
+func (r *SecondaryMEMWBRegister) GetIsFused() bool { return false }
+
 // WritebackSlot interface implementation for TertiaryMEMWBRegister
 
 // IsValid returns true if the register contains valid data.
@@ -1026,6 +1029,9 @@ func (r *TertiaryMEMWBRegister) GetALUResult() uint64 { return r.ALUResult }
 
 // GetMemData returns the data loaded from memory.
 func (r *TertiaryMEMWBRegister) GetMemData() uint64 { return r.MemData }
+
+// GetIsFused returns false as fusion only occurs in slot 0.
+func (r *TertiaryMEMWBRegister) GetIsFused() bool { return false }
 
 // WritebackSlot interface implementation for QuaternaryMEMWBRegister
 
@@ -1047,6 +1053,9 @@ func (r *QuaternaryMEMWBRegister) GetALUResult() uint64 { return r.ALUResult }
 // GetMemData returns the data loaded from memory.
 func (r *QuaternaryMEMWBRegister) GetMemData() uint64 { return r.MemData }
 
+// GetIsFused returns false as fusion only occurs in slot 0.
+func (r *QuaternaryMEMWBRegister) GetIsFused() bool { return false }
+
 // WritebackSlot interface implementation for QuinaryMEMWBRegister
 
 // IsValid returns true if the register contains valid data.
@@ -1067,6 +1076,9 @@ func (r *QuinaryMEMWBRegister) GetALUResult() uint64 { return r.ALUResult }
 // GetMemData returns the data loaded from memory.
 func (r *QuinaryMEMWBRegister) GetMemData() uint64 { return r.MemData }
 
+// GetIsFused returns false as fusion only occurs in slot 0.
+func (r *QuinaryMEMWBRegister) GetIsFused() bool { return false }
+
 // WritebackSlot interface implementation for SenaryMEMWBRegister
 
 // IsValid returns true if the register contains valid data.
@@ -1086,3 +1098,6 @@ func (r *SenaryMEMWBRegister) GetALUResult() uint64 { return r.ALUResult }
 
 // GetMemData returns the data loaded from memory.
 func (r *SenaryMEMWBRegister) GetMemData() uint64 { return r.MemData }
+
+// GetIsFused returns false as fusion only occurs in slot 0.
+func (r *SenaryMEMWBRegister) GetIsFused() bool { return false }


### PR DESCRIPTION
## Summary
Implements macro-op fusion for CMP followed immediately by B.cond, matching the behavior of Apple M2's decode-stage instruction fusion.

Closes #210

## Changes
- Add fusion detection in decode stage (tickSextupleIssue)
- When CMP+B.cond pattern is detected, fuse them into a single operation
- B.cond carries CMP operands and evaluates condition directly
- No separate PSTATE flag write/read - condition computed inline
- Fused instruction counts as 2 instructions when retired

## Results
- branch_taken_conditional benchmark: **62.5% error → 34.5% error**
- Simulator CPI: **1.933 → 1.600** (target: 1.190)

The fusion eliminates the flag dependency stall between CMP and B.cond, reducing CPI by ~0.3 for conditional branch patterns.

## Testing
- All existing tests pass (213 pipeline tests)
- Accuracy test shows measurable improvement
- go vet passes