### PR TITLE
[Bob] Enable 8-wide superscalar in benchmarks

### DIFF
--- a/benchmarks/timing_harness.go
+++ b/benchmarks/timing_harness.go
@@ -103,8 +103,11 @@ type HarnessConfig struct {
 	EnableQuadIssue bool
 
 	// EnableSextupleIssue enables 6-wide superscalar execution (overrides EnableQuadIssue)
-	// This matches the Apple M2's 6 integer ALUs
 	EnableSextupleIssue bool
+
+	// EnableOctupleIssue enables 8-wide superscalar execution (overrides EnableSextupleIssue)
+	// This matches the Apple M2's 8-wide decode capability
+	EnableOctupleIssue bool
 
 	// Output is where to write results (default: os.Stdout)
 	Output io.Writer
@@ -120,7 +123,8 @@ func DefaultConfig() HarnessConfig {
 		EnableDCache:        true,
 		EnableDualIssue:     false, // Superseded by higher-width options
 		EnableQuadIssue:     false, // Superseded by EnableSextupleIssue
-		EnableSextupleIssue: true,  // Enable 6-wide superscalar by default (matches M2)
+		EnableSextupleIssue: false, // Superseded by EnableOctupleIssue
+		EnableOctupleIssue:  true,  // Enable 8-wide superscalar by default (matches M2)
 		Output:              os.Stdout,
 		Verbose:             false,
 	}
@@ -190,7 +194,9 @@ func (h *Harness) runBenchmark(bench Benchmark) BenchmarkResult {
 	if h.config.EnableICache || h.config.EnableDCache {
 		opts = append(opts, pipeline.WithDefaultCaches())
 	}
-	if h.config.EnableSextupleIssue {
+	if h.config.EnableOctupleIssue {
+		opts = append(opts, pipeline.WithOctupleIssue())
+	} else if h.config.EnableSextupleIssue {
 		opts = append(opts, pipeline.WithSextupleIssue())
 	} else if h.config.EnableQuadIssue {
 		opts = append(opts, pipeline.WithQuadIssue())


### PR DESCRIPTION
## Summary
Enables 8-wide superscalar execution in the benchmark harness, completing the integration of issue #213's infrastructure.

## Changes
- Add `EnableOctupleIssue` config option to `HarnessConfig`
- Set 8-wide as default (matches M2's 8-wide decode capability per Eric's research)
- Update pipeline creation to support the 8-wide option

## Results
Calibration run with 8-wide enabled:
| Benchmark | Sim CPI | M2 CPI | Error |
|-----------|---------|--------|-------|
| arithmetic_sequential | 0.400 | 0.268 | 49.3% |
| dependency_chain | 1.200 | 1.009 | 18.9% |
| branch_taken_conditional | 1.600 | 1.190 | 34.5% |
| **Average** | — | — | **34.2%** |

Note: CPI unchanged because current microbenchmarks use only 5 registers (X0-X4), limiting parallelism to 5 instructions regardless of pipeline width. To fully benefit from 8-wide, we need benchmarks with 8+ independent register destinations.

## Recommendations for Future Work
- Add `arithmetic8Wide()` benchmark using registers X0-X7 to measure true 8-wide throughput
- Current 34.2% avg error is bottlenecked by register reuse, not pipeline width