### PR TITLE
[Bob] Improve branch predictor: increase BTB size 512→2048

### DIFF
--- a/timing/pipeline/branch_predictor.go
+++ b/timing/pipeline/branch_predictor.go
@@ -17,10 +17,12 @@ type BranchPredictorConfig struct {
 }
 
 // DefaultBranchPredictorConfig returns a default configuration.
+// The BTB size of 2048 is chosen to reduce cold-start penalties for
+// branch-heavy workloads. M2 Avalanche cores likely use 2K-4K BTB entries.
 func DefaultBranchPredictorConfig() BranchPredictorConfig {
 	return BranchPredictorConfig{
 		BHTSize:             4096,
-		BTBSize:             512,
+		BTBSize:             2048, // Increased from 512 to reduce cold-start penalty
 		GlobalHistoryLength: 12,
 		UseTournament:       true,
 	}

--- a/timing/pipeline/branch_predictor_test.go
+++ b/timing/pipeline/branch_predictor_test.go
@@ -267,7 +267,7 @@ var _ = Describe("BranchPredictor", func() {
 		It("should use sensible defaults", func() {
 			config := pipeline.DefaultBranchPredictorConfig()
 			Expect(config.BHTSize).To(Equal(uint32(4096)))
-			Expect(config.BTBSize).To(Equal(uint32(512)))
+			Expect(config.BTBSize).To(Equal(uint32(2048)))
 			Expect(config.GlobalHistoryLength).To(Equal(uint32(12)))
 			Expect(config.UseTournament).To(BeTrue())
 		})

--- a/timing/pipeline/pipeline.go
+++ b/timing/pipeline/pipeline.go
@@ -139,6 +139,14 @@ func WithDefaultCaches() PipelineOption {
 	}
 }
 
+// WithBranchPredictorConfig sets a custom branch predictor configuration.
+// This allows tuning BTB size, BHT size, global history length, etc.
+func WithBranchPredictorConfig(config BranchPredictorConfig) PipelineOption {
+	return func(p *Pipeline) {
+		p.branchPredictor = NewBranchPredictor(config)
+	}
+}
+
 // Pipeline implements a 5-stage pipelined CPU model.
 // Stages: Fetch (IF) -> Decode (ID) -> Execute (EX) -> Memory (MEM) -> Writeback (WB)
 // Supports optional superscalar (dual-issue) execution for independent instructions.


### PR DESCRIPTION
## Summary

Increase the default BTB (Branch Target Buffer) size from 512 to 2048 entries to reduce cold-start penalties for branch-heavy workloads. Also adds a functional option for custom branch predictor configuration.

## Changes

1. **Increase default BTB size from 512 to 2048**
   - Reduces cold-start penalty for branches not yet seen
   - M2 Avalanche cores likely use 2K-4K BTB entries based on research
   - Expected 5-10% improvement on branch-heavy code

2. **Add `WithBranchPredictorConfig()` functional option**
   - Allows custom configuration of BTB size, BHT size, global history length, etc.
   - Enables experimentation with branch predictor parameters

## Context

This is part of the branch predictor tuning effort to reduce the 34.5% branch_conditional error toward <25% target. Eric's research (cycle 239) recommended:

| Priority | Optimization | Expected Impact |
|----------|--------------|-----------------|
| 1 | Zero-cycle predicted-taken branches | 34.5%→~20% |
| 2 | Increase BTB 512→2048 | ~5% ← **This PR** |
| 3 | Add branch stats logging | Diagnostic |

This is the low-effort option that can be validated quickly before tackling the more complex zero-cycle branch optimization.

## Testing

- All 213 pipeline tests pass ✅
- Build succeeds ✅

## Related

- Part of branch predictor improvement work
- Follow-up to Eric's branch predictor research (cycle 237-239)