### PR TITLE
[Bob] Add PolyBench gemm benchmark (Phase 1)

### DIFF
--- a/benchmarks/polybench/.gitignore
+++ b/benchmarks/polybench/.gitignore
@@ -1,0 +1,4 @@
+# Build artifacts
+*.o
+*.elf
+*.dis

--- a/benchmarks/polybench/README.md
+++ b/benchmarks/polybench/README.md
@@ -1,0 +1,60 @@
+# PolyBench for M2Sim
+
+Bare-metal adaptations of PolyBench/C benchmarks for M2Sim timing validation.
+
+## Overview
+
+This directory contains bare-metal versions of PolyBench kernels adapted for
+the M2Sim simulator. The benchmarks use:
+
+- Integer arithmetic (no FPU dependencies)
+- Static array allocation (no malloc/libc)
+- MINI dataset sizes (16×16 matrices)
+- Exit via syscall (bare-metal compatible)
+
+## Benchmarks
+
+### Phase 1 (Current)
+
+| Benchmark | Description | Operations |
+|-----------|-------------|------------|
+| gemm | Matrix multiply C=αAB+βC | 16×16×16 = 4,096 MACs |
+
+### Phase 2 (Planned)
+
+| Benchmark | Description |
+|-----------|-------------|
+| atax | Matrix transpose + vector multiply |
+
+## Building
+
+Requires `aarch64-elf-gcc` cross-compiler.
+
+```bash
+# Build all benchmarks
+./build.sh
+
+# Build specific benchmark
+./build.sh gemm
+
+# Clean build artifacts
+./build.sh clean
+```
+
+## Output Files
+
+- `gemm_m2sim.elf` - Bare-metal ELF binary
+- `gemm_m2sim.dis` - Disassembly listing
+
+## Running with M2Sim
+
+```bash
+# From repository root
+go test -run TestPolybenchGemm -v ./benchmarks/
+```
+
+## References
+
+- [PolyBench/C 4.2.1](https://github.com/MatthiasJReisinger/PolyBenchC-4.2.1)
+- Issue #237: PolyBench Phase 1
+- `docs/polybench-implementation-approach.md`

--- a/benchmarks/polybench/build.sh
+++ b/benchmarks/polybench/build.sh
@@ -1,0 +1,82 @@
+#!/bin/bash
+# Build script for PolyBench M2Sim bare-metal benchmarks
+#
+# Usage: ./build.sh [benchmark]
+#   benchmark: gemm (default: all)
+
+set -e
+
+# Cross-compiler
+CC=aarch64-elf-gcc
+OBJDUMP=aarch64-elf-objdump
+
+# Script directory
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+# Compiler flags
+# -fno-tree-vectorize: Disable auto-vectorization (M2Sim doesn't support NEON yet)
+CFLAGS="-O2 -ffreestanding -nostdlib -mcpu=apple-m2"
+CFLAGS+=" -fno-tree-vectorize -fno-tree-loop-vectorize"
+CFLAGS+=" -I$SCRIPT_DIR/common"
+CFLAGS+=" -DPOLYBENCH_USE_RESTRICT"
+CFLAGS+=" -DMINI_DATASET"
+
+# Available benchmarks
+BENCHMARKS="gemm"
+
+# Build function
+build_benchmark() {
+    local name=$1
+    local src_dir="$SCRIPT_DIR/$name"
+    
+    if [ ! -d "$src_dir" ]; then
+        echo "Error: Benchmark directory $src_dir not found"
+        return 1
+    fi
+    
+    echo "Building $name for M2Sim..."
+    
+    # Compile benchmark source
+    $CC $CFLAGS -c "$src_dir/$name.c" -o "$SCRIPT_DIR/$name.o"
+    
+    # Compile startup code
+    $CC $CFLAGS -c "$SCRIPT_DIR/common/startup.S" -o "$SCRIPT_DIR/startup.o"
+    
+    # Link
+    $CC $CFLAGS -T "$SCRIPT_DIR/linker.ld" \
+        "$SCRIPT_DIR/startup.o" \
+        "$SCRIPT_DIR/$name.o" \
+        -o "$SCRIPT_DIR/${name}_m2sim.elf" \
+        -lgcc
+    
+    # Generate disassembly
+    $OBJDUMP -d "$SCRIPT_DIR/${name}_m2sim.elf" > "$SCRIPT_DIR/${name}_m2sim.dis"
+    
+    echo "Build complete: ${name}_m2sim.elf"
+    ls -la "$SCRIPT_DIR/${name}_m2sim.elf"
+}
+
+# Clean function
+clean() {
+    echo "Cleaning build artifacts..."
+    rm -f "$SCRIPT_DIR"/*.o
+    rm -f "$SCRIPT_DIR"/*_m2sim.elf
+    rm -f "$SCRIPT_DIR"/*_m2sim.dis
+}
+
+# Main
+case "${1:-all}" in
+    clean)
+        clean
+        ;;
+    all)
+        for bench in $BENCHMARKS; do
+            build_benchmark "$bench"
+        done
+        ;;
+    *)
+        build_benchmark "$1"
+        ;;
+esac
+
+echo "Done."

--- a/benchmarks/polybench/common/polybench.h
+++ b/benchmarks/polybench/common/polybench.h
@@ -1,0 +1,46 @@
+/**
+ * polybench.h - Minimal bare-metal PolyBench header for M2Sim
+ *
+ * This is a stripped-down version of polybench.h that removes all
+ * libc dependencies for bare-metal execution on M2Sim.
+ */
+
+#ifndef _POLYBENCH_H
+#define _POLYBENCH_H
+
+/* Dataset sizes - using MINI for fast validation */
+#ifndef MINI_DATASET
+#define MINI_DATASET
+#endif
+
+/* GEMM matrix dimensions (MINI) */
+#ifdef MINI_DATASET
+  #define NI 16
+  #define NJ 16
+  #define NK 16
+#endif
+
+/* Integer data type for bare-metal (no FPU dependencies) */
+typedef int DATA_TYPE;
+
+/* Timing macros - stubs for bare-metal */
+#define polybench_start_instruments
+#define polybench_stop_instruments
+#define polybench_print_instruments
+
+/* Prevent array scalarization - use restrict qualifier */
+#ifdef POLYBENCH_USE_RESTRICT
+  #define POLYBENCH_RESTRICT __restrict
+#else
+  #define POLYBENCH_RESTRICT
+#endif
+
+/* Declare 2D array type */
+#define POLYBENCH_2D_ARRAY_DECL(var, type, d1, d2, name) \
+    type var[d1][d2]
+
+/* Static allocation helpers */
+#define POLYBENCH_ALLOC_2D_ARRAY(n1, n2, type) /* noop - static arrays */
+#define POLYBENCH_FREE_ARRAY(x) /* noop - static arrays */
+
+#endif /* _POLYBENCH_H */

--- a/benchmarks/polybench/common/startup.S
+++ b/benchmarks/polybench/common/startup.S
@@ -1,0 +1,41 @@
+/* M2Sim bare-metal startup for PolyBench benchmarks */
+.section .text.startup
+.global _start
+.type _start, %function
+
+_start:
+    /* Set up stack pointer */
+    adrp x0, __stack_top
+    add x0, x0, :lo12:__stack_top
+    mov sp, x0
+    
+    /* Clear BSS section */
+    adrp x0, __bss_start
+    add x0, x0, :lo12:__bss_start
+    adrp x1, __bss_end
+    add x1, x1, :lo12:__bss_end
+    mov x2, #0
+1:
+    cmp x0, x1
+    b.ge 2f
+    str x2, [x0], #8
+    b 1b
+2:
+    
+    /* Call main benchmark */
+    bl main
+    
+    /* Store result in global variable */
+    adrp x1, result
+    add x1, x1, :lo12:result
+    str w0, [x1]
+    
+    /* Exit via syscall */
+    mov x8, #93     /* exit syscall number */
+    mov x0, #0      /* exit code 0 = success */
+    svc #0          /* syscall */
+
+.section .data
+.global result
+result:
+    .word 0

--- a/benchmarks/polybench/gemm/gemm.c
+++ b/benchmarks/polybench/gemm/gemm.c
@@ -1,0 +1,111 @@
+/**
+ * gemm.c - General Matrix Multiply for M2Sim
+ *
+ * Computes: C := alpha*A*B + beta*C
+ *
+ * This is a bare-metal adaptation of the PolyBench GEMM kernel,
+ * using integer arithmetic and static arrays for M2Sim validation.
+ *
+ * Original: PolyBench/C 4.2.1 (linear-algebra/blas/gemm)
+ * Modified: Bare-metal, integer-only, MINI dataset
+ */
+
+#include "../common/polybench.h"
+
+/* Scaling factors (integer version) */
+#define ALPHA 1
+#define BETA 1
+
+/* Static arrays for MINI dataset (16x16) */
+static DATA_TYPE A[NI][NK];
+static DATA_TYPE B[NK][NJ];
+static DATA_TYPE C[NI][NJ];
+
+/**
+ * Initialize arrays with deterministic values
+ * A[i][k] = (i * NK + k) % 256
+ * B[k][j] = (k * NJ + j) % 256
+ * C[i][j] = (i * NJ + j) % 256
+ */
+static void init_array(void) {
+    int i, j, k;
+    
+    for (i = 0; i < NI; i++) {
+        for (k = 0; k < NK; k++) {
+            A[i][k] = (i * NK + k) % 256;
+        }
+    }
+    
+    for (k = 0; k < NK; k++) {
+        for (j = 0; j < NJ; j++) {
+            B[k][j] = (k * NJ + j) % 256;
+        }
+    }
+    
+    for (i = 0; i < NI; i++) {
+        for (j = 0; j < NJ; j++) {
+            C[i][j] = (i * NJ + j) % 256;
+        }
+    }
+}
+
+/**
+ * GEMM kernel: C := alpha*A*B + beta*C
+ *
+ * Triple-nested loop with O(n^3) operations.
+ * Using i-k-j loop order for better cache behavior.
+ */
+static void kernel_gemm(void) {
+    int i, j, k;
+    
+    polybench_start_instruments;
+    
+    /* Scale C by beta */
+    for (i = 0; i < NI; i++) {
+        for (j = 0; j < NJ; j++) {
+            C[i][j] *= BETA;
+        }
+    }
+    
+    /* Compute C += alpha * A * B */
+    for (i = 0; i < NI; i++) {
+        for (k = 0; k < NK; k++) {
+            for (j = 0; j < NJ; j++) {
+                C[i][j] += ALPHA * A[i][k] * B[k][j];
+            }
+        }
+    }
+    
+    polybench_stop_instruments;
+}
+
+/**
+ * Compute checksum of result matrix
+ * Returns lower 8 bits of sum for validation
+ */
+static int compute_checksum(void) {
+    int i, j;
+    int sum = 0;
+    
+    for (i = 0; i < NI; i++) {
+        for (j = 0; j < NJ; j++) {
+            sum += C[i][j];
+        }
+    }
+    
+    return sum & 0xFF;
+}
+
+/**
+ * Main entry point
+ */
+int main(void) {
+    /* Initialize arrays */
+    init_array();
+    
+    /* Run GEMM kernel */
+    kernel_gemm();
+    
+    /* Return checksum for validation */
+    return compute_checksum();
+}

--- a/benchmarks/polybench/linker.ld
+++ b/benchmarks/polybench/linker.ld
@@ -1,0 +1,34 @@
+/* M2Sim bare-metal linker script for PolyBench benchmarks */
+ENTRY(_start)
+
+MEMORY {
+    RAM (rwx) : ORIGIN = 0x80000, LENGTH = 1M
+}
+
+SECTIONS {
+    . = 0x80000;
+    
+    .text : {
+        *(.text.startup)
+        *(.text*)
+    } > RAM
+    
+    .rodata : {
+        *(.rodata*)
+    } > RAM
+    
+    .data : {
+        *(.data*)
+    } > RAM
+    
+    .bss : {
+        __bss_start = .;
+        *(.bss*)
+        *(COMMON)
+        __bss_end = .;
+    } > RAM
+    
+    . = ALIGN(16);
+    . = . + 0x10000;  /* 64KB stack */
+    __stack_top = .;
+}


### PR DESCRIPTION
## Summary

Implements Phase 1 of PolyBench integration (#237) - the GEMM (General Matrix Multiply) benchmark.

## Changes

- Adds `benchmarks/polybench/` directory structure
- GEMM kernel: `C := α*A*B + β*C` with 16×16×16 matrices
- Bare-metal build system (no libc dependencies)
- Cross-compilation with `aarch64-elf-gcc`

## Technical Details

- **Integer-only**: Uses `int` data type (no FPU)
- **Static allocation**: No malloc, fixed-size arrays
- **MINI dataset**: 16×16 matrices for fast validation
- **~37K instructions**: Validated working in emulator
- **No NEON**: Disabled vectorization (M2Sim doesn't support SIMD yet)

## Verified

```
$ go run ./cmd/m2sim -v benchmarks/polybench/gemm_m2sim.elf
Loaded: benchmarks/polybench/gemm_m2sim.elf
Entry point: 0x80000
Segments: 1

Program: benchmarks/polybench/gemm_m2sim.elf
Exit code: 0
Instructions executed: 37603
```

## Closes

Partially addresses #237 (gemm portion of Phase 1)

## Next Steps

- →Cathy: Review build configuration
- Phase 2: Add `atax` benchmark
- Capture M2 baseline timing data