### PR TITLE
[Bob] Add PolyBench atax benchmark

### DIFF
--- a/benchmarks/polybench/atax/atax.c
+++ b/benchmarks/polybench/atax/atax.c
@@ -1,0 +1,104 @@
+/**
+ * atax.c - Matrix Transpose and Vector Multiplication for M2Sim
+ *
+ * Computes: y = A^T * (A * x)
+ *
+ * This is a bare-metal adaptation of the PolyBench ATAX kernel,
+ * using integer arithmetic and static arrays for M2Sim validation.
+ *
+ * Original: PolyBench/C 4.2.1 (linear-algebra/kernels/atax)
+ * Modified: Bare-metal, integer-only, MINI dataset
+ */
+
+#include "../common/polybench.h"
+
+/* Static arrays for MINI dataset (16x16) */
+static DATA_TYPE A[NX][NY];
+static DATA_TYPE x[NY];
+static DATA_TYPE y[NY];
+static DATA_TYPE tmp[NX];
+
+/**
+ * Initialize arrays with deterministic values
+ * A[i][j] = (i * NY + j) % 256
+ * x[i] = i % 256
+ * y[i] = 0
+ * tmp[i] = 0
+ */
+static void init_array(void) {
+    int i, j;
+    
+    for (i = 0; i < NX; i++) {
+        for (j = 0; j < NY; j++) {
+            A[i][j] = ((i * NY) + j) % 256;
+        }
+    }
+    
+    for (i = 0; i < NY; i++) {
+        x[i] = i % 256;
+        y[i] = 0;
+    }
+    
+    for (i = 0; i < NX; i++) {
+        tmp[i] = 0;
+    }
+}
+
+/**
+ * ATAX kernel: y = A^T * (A * x)
+ *
+ * Step 1: tmp = A * x
+ * Step 2: y = A^T * tmp
+ */
+static void kernel_atax(void) {
+    int i, j;
+    
+    polybench_start_instruments;
+    
+    /* tmp = A * x */
+    for (i = 0; i < NX; i++) {
+        tmp[i] = 0;
+        for (j = 0; j < NY; j++) {
+            tmp[i] += A[i][j] * x[j];
+        }
+    }
+    
+    /* y = A^T * tmp */
+    for (j = 0; j < NY; j++) {
+        y[j] = 0;
+        for (i = 0; i < NX; i++) {
+            y[j] += A[i][j] * tmp[i];
+        }
+    }
+    
+    polybench_stop_instruments;
+}
+
+/**
+ * Compute checksum of result vector
+ * Returns lower 8 bits of sum for validation
+ */
+static int compute_checksum(void) {
+    int i;
+    int sum = 0;
+    
+    for (i = 0; i < NY; i++) {
+        sum += y[i];
+    }
+    
+    return sum & 0xFF;
+}
+
+/**
+ * Main entry point
+ */
+int main(void) {
+    /* Initialize arrays */
+    init_array();
+    
+    /* Run ATAX kernel */
+    kernel_atax();
+    
+    /* Return checksum for validation */
+    return compute_checksum();
+}

--- a/benchmarks/polybench/build.sh
+++ b/benchmarks/polybench/build.sh
@@ -22,7 +22,7 @@ CFLAGS+=" -DPOLYBENCH_USE_RESTRICT"
 CFLAGS+=" -DMINI_DATASET"
 
 # Available benchmarks
-BENCHMARKS="gemm"
+BENCHMARKS="gemm atax"
 
 # Build function
 build_benchmark() {

--- a/benchmarks/polybench/common/polybench.h
+++ b/benchmarks/polybench/common/polybench.h
@@ -20,6 +20,12 @@
   #define NK 16
 #endif
 
+/* ATAX matrix dimensions (MINI) */
+#ifdef MINI_DATASET
+  #define NX 16
+  #define NY 16
+#endif
+
 /* Integer data type for bare-metal (no FPU dependencies) */
 typedef int DATA_TYPE;
 


### PR DESCRIPTION
Part of PolyBench Phase 1 (#237)

## Summary
Implements the ATAX kernel: y = A^T * (A * x)

This is a matrix transpose and vector multiplication benchmark from PolyBench/C, adapted for bare-metal execution on M2Sim.

## Changes
- Added `benchmarks/polybench/atax/atax.c` - ATAX kernel implementation
- Updated `polybench.h` with NX/NY dimension definitions for ATAX
- Updated `build.sh` to include atax in the benchmark list

## Technical Details
- Uses MINI dataset (16x16 matrix)
- Integer arithmetic only (no FPU dependencies)
- Static arrays for bare-metal execution
- Deterministic initialization for reproducibility
- Returns checksum for validation

## Verified
- Emulation: 5,233 instructions, exit code 0 ✅
- Build: aarch64-elf-gcc cross-compilation successful

## Related Issues
- Closes part of #237 (PolyBench Phase 1)
- Supports #132 (Intermediate benchmarks for validation)