### PR TITLE
[Cathy] Add read syscall tests

### DIFF
--- a/emu/syscall_test.go
+++ b/emu/syscall_test.go
@@ -3,6 +3,7 @@ package emu_test
 
 import (
 	"bytes"
+	"strings"
 
 	. "github.com/onsi/ginkgo/v2"
 	. "github.com/onsi/gomega"
@@ -142,6 +143,146 @@ var _ = Describe("Syscall Handler", func() {
 			Expect(result.Exited).To(BeFalse())
 			Expect(stderr.String()).To(Equal("err"))
 			Expect(regFile.ReadReg(0)).To(Equal(uint64(3)))
+		})
+	})
+
+	Describe("Read syscall from stdin", func() {
+		It("should read buffer from stdin", func() {
+			stdin := strings.NewReader("hello")
+			handler.SetStdin(stdin)
+
+			// Set up read syscall
+			regFile.WriteReg(8, 63)     // SyscallRead
+			regFile.WriteReg(0, 0)      // stdin
+			regFile.WriteReg(1, 0x1000) // buf pointer
+			regFile.WriteReg(2, 5)      // count
+
+			result := handler.Handle()
+
+			Expect(result.Exited).To(BeFalse())
+			// X0 should contain bytes read
+			Expect(regFile.ReadReg(0)).To(Equal(uint64(5)))
+			// Verify memory contains "hello"
+			Expect(memory.Read8(0x1000)).To(Equal(byte('h')))
+			Expect(memory.Read8(0x1001)).To(Equal(byte('e')))
+			Expect(memory.Read8(0x1002)).To(Equal(byte('l')))
+			Expect(memory.Read8(0x1003)).To(Equal(byte('l')))
+			Expect(memory.Read8(0x1004)).To(Equal(byte('o')))
+		})
+
+		It("should handle partial reads", func() {
+			stdin := strings.NewReader("hi")
+			handler.SetStdin(stdin)
+
+			// Request more bytes than available
+			regFile.WriteReg(8, 63)     // SyscallRead
+			regFile.WriteReg(0, 0)      // stdin
+			regFile.WriteReg(1, 0x1000) // buf pointer
+			regFile.WriteReg(2, 100)    // count (request 100 bytes)
+
+			result := handler.Handle()
+
+			Expect(result.Exited).To(BeFalse())
+			// X0 should contain actual bytes read (2)
+			Expect(regFile.ReadReg(0)).To(Equal(uint64(2)))
+			// Verify memory contains "hi"
+			Expect(memory.Read8(0x1000)).To(Equal(byte('h')))
+			Expect(memory.Read8(0x1001)).To(Equal(byte('i')))
+		})
+
+		It("should return 0 when stdin is nil (EOF)", func() {
+			// No stdin configured (nil by default)
+			regFile.WriteReg(8, 63)     // SyscallRead
+			regFile.WriteReg(0, 0)      // stdin
+			regFile.WriteReg(1, 0x1000) // buf pointer
+			regFile.WriteReg(2, 10)     // count
+
+			result := handler.Handle()
+
+			Expect(result.Exited).To(BeFalse())
+			// X0 should be 0 (EOF)
+			Expect(regFile.ReadReg(0)).To(Equal(uint64(0)))
+		})
+
+		It("should return 0 on EOF from exhausted reader", func() {
+			stdin := strings.NewReader("")
+			handler.SetStdin(stdin)
+
+			regFile.WriteReg(8, 63)     // SyscallRead
+			regFile.WriteReg(0, 0)      // stdin
+			regFile.WriteReg(1, 0x1000) // buf pointer
+			regFile.WriteReg(2, 10)     // count
+
+			result := handler.Handle()
+
+			Expect(result.Exited).To(BeFalse())
+			// X0 should be 0 (EOF)
+			Expect(regFile.ReadReg(0)).To(Equal(uint64(0)))
+		})
+
+		It("should handle zero count read", func() {
+			stdin := strings.NewReader("hello")
+			handler.SetStdin(stdin)
+
+			regFile.WriteReg(8, 63)     // SyscallRead
+			regFile.WriteReg(0, 0)      // stdin
+			regFile.WriteReg(1, 0x1000) // buf pointer
+			regFile.WriteReg(2, 0)      // count = 0
+
+			result := handler.Handle()
+
+			Expect(result.Exited).To(BeFalse())
+			// X0 should be 0 (no bytes read)
+			Expect(regFile.ReadReg(0)).To(Equal(uint64(0)))
+		})
+	})
+
+	Describe("Read syscall with bad fd", func() {
+		It("should return EBADF for invalid file descriptor", func() {
+			// Set up read syscall with invalid fd
+			regFile.WriteReg(8, 63) // SyscallRead
+			regFile.WriteReg(0, 42) // Invalid fd (not 0)
+			regFile.WriteReg(1, 0)  // buf pointer
+			regFile.WriteReg(2, 5)  // count
+
+			result := handler.Handle()
+
+			Expect(result.Exited).To(BeFalse())
+			// X0 should contain -EBADF (9)
+			x0 := regFile.ReadReg(0)
+			var ebadf int64 = 9
+			expectedError := uint64(-ebadf) // -EBADF
+			Expect(x0).To(Equal(expectedError))
+		})
+
+		It("should return EBADF for stdout fd on read", func() {
+			regFile.WriteReg(8, 63) // SyscallRead
+			regFile.WriteReg(0, 1)  // stdout (invalid for read)
+			regFile.WriteReg(1, 0)  // buf pointer
+			regFile.WriteReg(2, 5)  // count
+
+			result := handler.Handle()
+
+			Expect(result.Exited).To(BeFalse())
+			x0 := regFile.ReadReg(0)
+			var ebadf int64 = 9
+			expectedError := uint64(-ebadf)
+			Expect(x0).To(Equal(expectedError))
+		})
+
+		It("should return EBADF for stderr fd on read", func() {
+			regFile.WriteReg(8, 63) // SyscallRead
+			regFile.WriteReg(0, 2)  // stderr (invalid for read)
+			regFile.WriteReg(1, 0)  // buf pointer
+			regFile.WriteReg(2, 5)  // count
+
+			result := handler.Handle()
+
+			Expect(result.Exited).To(BeFalse())
+			x0 := regFile.ReadReg(0)
+			var ebadf int64 = 9
+			expectedError := uint64(-ebadf)
+			Expect(x0).To(Equal(expectedError))
 		})
 	})
 })


### PR DESCRIPTION
## Summary
- Adds comprehensive test coverage for the read syscall (63) implementation

## Test Coverage
- **Happy path:** Read buffer from stdin
- **Partial reads:** Request more bytes than available
- **EOF handling:** When stdin is nil, returns 0
- **Empty reader:** Returns 0 on exhausted reader
- **Zero count:** Handles count=0 correctly
- **Error cases:** EBADF for invalid file descriptors

## Tests Added (8 new tests)
1. should read buffer from stdin
2. should handle partial reads
3. should return 0 when stdin is nil (EOF)
4. should return 0 on EOF from exhausted reader
5. should handle zero count read
6. should return EBADF for invalid file descriptor
7. should return EBADF for stdout fd on read
8. should return EBADF for stderr fd on read

**Note:** This PR targets Bob's read syscall branch (bob/257-read-syscall) and should be merged after PR #264.

🤖 Generated with [Claude Code](https://claude.com/claude-code)