### PR TITLE
[Maya] Expand microbenchmark suite for calibration

### DIFF
--- a/benchmarks/timing_harness_test.go
+++ b/benchmarks/timing_harness_test.go
@@ -20,8 +20,8 @@ func TestHarnessRunsAllBenchmarks(t *testing.T) {
 
 	results := harness.RunAll()
 
-	if len(results) != 12 {
-		t.Errorf("expected 12 benchmark results, got %d", len(results))
+	if len(results) != 16 {
+		t.Errorf("expected 16 benchmark results, got %d", len(results))
 	}
 
 	// Verify each benchmark completed
@@ -185,6 +185,102 @@ func TestMixedOperations(t *testing.T) {
 
 	t.Logf("mixed_operations: cycles=%d, insts=%d, CPI=%.3f",
 		r.SimulatedCycles, r.InstructionsRetired, r.CPI)
+}
+
+func TestMemoryStrided(t *testing.T) {
+	config := DefaultConfig()
+	config.Output = &bytes.Buffer{}
+	config.EnableICache = false
+	config.EnableDCache = false
+
+	harness := NewHarness(config)
+	harness.AddBenchmark(memoryStrided())
+
+	results := harness.RunAll()
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+
+	r := results[0]
+	if r.ExitCode != 7 {
+		t.Errorf("expected exit code 7, got %d", r.ExitCode)
+	}
+
+	t.Logf("memory_strided: cycles=%d, insts=%d, CPI=%.3f",
+		r.SimulatedCycles, r.InstructionsRetired, r.CPI)
+}
+
+func TestLoadHeavy(t *testing.T) {
+	config := DefaultConfig()
+	config.Output = &bytes.Buffer{}
+	config.EnableICache = false
+	config.EnableDCache = false
+
+	harness := NewHarness(config)
+	harness.AddBenchmark(loadHeavy())
+
+	results := harness.RunAll()
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+
+	r := results[0]
+	if r.ExitCode != 20 {
+		t.Errorf("expected exit code 20, got %d", r.ExitCode)
+	}
+
+	t.Logf("load_heavy: cycles=%d, insts=%d, CPI=%.3f",
+		r.SimulatedCycles, r.InstructionsRetired, r.CPI)
+}
+
+func TestStoreHeavy(t *testing.T) {
+	config := DefaultConfig()
+	config.Output = &bytes.Buffer{}
+	config.EnableICache = false
+	config.EnableDCache = false
+
+	harness := NewHarness(config)
+	harness.AddBenchmark(storeHeavy())
+
+	results := harness.RunAll()
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+
+	r := results[0]
+	if r.ExitCode != 3 {
+		t.Errorf("expected exit code 3, got %d", r.ExitCode)
+	}
+
+	t.Logf("store_heavy: cycles=%d, insts=%d, CPI=%.3f",
+		r.SimulatedCycles, r.InstructionsRetired, r.CPI)
+}
+
+func TestBranchHeavy(t *testing.T) {
+	config := DefaultConfig()
+	config.Output = &bytes.Buffer{}
+	config.EnableICache = false
+	config.EnableDCache = false
+
+	harness := NewHarness(config)
+	harness.AddBenchmark(branchHeavy())
+
+	results := harness.RunAll()
+
+	if len(results) != 1 {
+		t.Fatalf("expected 1 result, got %d", len(results))
+	}
+
+	r := results[0]
+	if r.ExitCode != 10 {
+		t.Errorf("expected exit code 10, got %d", r.ExitCode)
+	}
+
+	t.Logf("branch_heavy: cycles=%d, insts=%d, CPI=%.3f, flushes=%d",
+		r.SimulatedCycles, r.InstructionsRetired, r.CPI, r.PipelineFlushes)
 }
 
 func TestPrintResults(t *testing.T) {


### PR DESCRIPTION
## Summary
- Adds 4 new microbenchmarks targeting under-covered CPU behaviors for M2 calibration:
  - **memory_strided**: Strided store/load pairs (stride-4) — measures strided memory access latency
  - **load_heavy**: 20 sequential loads to independent registers — measures load unit throughput
  - **store_heavy**: 20 sequential stores — measures store unit throughput
  - **branch_heavy**: 10 conditional branches (5 taken, 5 not-taken) — stresses branch predictor with alternating patterns
- Updates `GetMicrobenchmarks()` from 12 to 16 benchmarks
- Adds individual tests for each new benchmark verifying exit codes
- Adds `EncodeCMPReg` helper for register-register compare encoding

Partially addresses #290

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./...` — all packages pass
- [x] `golangci-lint run ./...` — no issues
- [x] New benchmarks produce correct exit codes
- [x] Existing benchmark tests unchanged and passing

🤖 Generated with [Claude Code](https://claude.com/claude-code)