### PR TITLE
[Leo] Set up ARM64 cross-compilation for SPEC benchmarks

### DIFF
--- a/benchmarks/build_spec.sh
+++ b/benchmarks/build_spec.sh
@@ -1,0 +1,120 @@
+#!/bin/bash
+# Build SPEC CPU 2017 benchmarks as static ARM64 Linux ELF binaries for M2Sim.
+#
+# Prerequisites:
+#   - brew install FiloSottile/musl-cross/musl-cross  (provides aarch64-linux-musl-gcc)
+#   - Docker (for Fortran benchmarks)
+#   - SPEC source at benchmarks/spec (symlink to SPEC installation)
+#
+# Usage: ./build_spec.sh [benchmark]
+#   benchmark: 505.mcf_r | 531.deepsjeng_r | 548.exchange2_r | all (default: all)
+
+set -e
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+SPEC_DIR="${SCRIPT_DIR}/spec"
+
+if [ ! -d "${SPEC_DIR}/benchspec/CPU" ]; then
+    echo "Error: SPEC not found at ${SPEC_DIR}"
+    echo "Create a symlink: ln -s /path/to/spec ${SPEC_DIR}"
+    exit 1
+fi
+
+CC=aarch64-linux-musl-gcc
+CXX=aarch64-linux-musl-g++
+
+build_505_mcf_r() {
+    echo "Building 505.mcf_r..."
+    local SRC="${SPEC_DIR}/benchspec/CPU/505.mcf_r/src"
+    local EXE_DIR="${SPEC_DIR}/benchspec/CPU/505.mcf_r/exe"
+    mkdir -p "${EXE_DIR}"
+
+    ${CC} -static -O2 -DSPEC -DSPEC_LP64 \
+        -I"${SRC}" -I"${SRC}/spec_qsort" \
+        "${SRC}"/*.c "${SRC}"/spec_qsort/spec_qsort.c \
+        -o "${EXE_DIR}/mcf_r_base.arm64" -lm
+
+    echo "  -> $(file "${EXE_DIR}/mcf_r_base.arm64")"
+
+    # Set up test run directory
+    local RUN_DIR="${SPEC_DIR}/benchspec/CPU/505.mcf_r/run/run_base_test_arm64.0000"
+    mkdir -p "${RUN_DIR}"
+    cp "${SPEC_DIR}/benchspec/CPU/505.mcf_r/data/test/input/inp.in" "${RUN_DIR}/"
+    echo "  Test input staged at ${RUN_DIR}"
+}
+
+build_531_deepsjeng_r() {
+    echo "Building 531.deepsjeng_r..."
+    local SRC="${SPEC_DIR}/benchspec/CPU/531.deepsjeng_r/src"
+    local EXE_DIR="${SPEC_DIR}/benchspec/CPU/531.deepsjeng_r/exe"
+    mkdir -p "${EXE_DIR}"
+
+    ${CXX} -static -O2 -DSPEC -DSMALL_MEMORY \
+        -I"${SRC}" \
+        "${SRC}"/*.cpp \
+        -o "${EXE_DIR}/deepsjeng_r_base.arm64"
+
+    echo "  -> $(file "${EXE_DIR}/deepsjeng_r_base.arm64")"
+
+    # Set up test run directory
+    local RUN_DIR="${SPEC_DIR}/benchspec/CPU/531.deepsjeng_r/run/run_base_test_arm64.0000"
+    mkdir -p "${RUN_DIR}"
+    cp "${SPEC_DIR}/benchspec/CPU/531.deepsjeng_r/data/test/input/test.txt" "${RUN_DIR}/"
+    echo "  Test input staged at ${RUN_DIR}"
+}
+
+build_548_exchange2_r() {
+    echo "Building 548.exchange2_r (via Docker, Fortran)..."
+    local SRC="${SPEC_DIR}/benchspec/CPU/548.exchange2_r/src"
+    local EXE_DIR="${SPEC_DIR}/benchspec/CPU/548.exchange2_r/exe"
+    mkdir -p "${EXE_DIR}"
+
+    local TMPDIR
+    TMPDIR=$(mktemp -d)
+
+    docker run --rm --platform linux/arm64 \
+        -v "${SRC}:/src:ro" \
+        -v "${TMPDIR}:/out" \
+        alpine:latest sh -c \
+        "apk add --no-cache gfortran musl-dev && \
+         gfortran -static -no-pie -O2 -DSPEC -cpp \
+         -o /out/exchange2_r_base.arm64 /src/exchange2.F90"
+
+    cp "${TMPDIR}/exchange2_r_base.arm64" "${EXE_DIR}/"
+    rm -rf "${TMPDIR}"
+
+    echo "  -> $(file "${EXE_DIR}/exchange2_r_base.arm64")"
+
+    # Set up test run directory
+    local RUN_DIR="${SPEC_DIR}/benchspec/CPU/548.exchange2_r/run/run_base_test_arm64.0000"
+    mkdir -p "${RUN_DIR}"
+    cp "${SPEC_DIR}/benchspec/CPU/548.exchange2_r/data/test/input/control" "${RUN_DIR}/"
+    cp "${SPEC_DIR}/benchspec/CPU/548.exchange2_r/data/all/input/puzzles.txt" "${RUN_DIR}/"
+    echo "  Test input staged at ${RUN_DIR}"
+}
+
+TARGET="${1:-all}"
+
+case "${TARGET}" in
+    505.mcf_r)
+        build_505_mcf_r
+        ;;
+    531.deepsjeng_r)
+        build_531_deepsjeng_r
+        ;;
+    548.exchange2_r)
+        build_548_exchange2_r
+        ;;
+    all)
+        build_505_mcf_r
+        build_531_deepsjeng_r
+        build_548_exchange2_r
+        ;;
+    *)
+        echo "Unknown benchmark: ${TARGET}"
+        echo "Usage: $0 [505.mcf_r|531.deepsjeng_r|548.exchange2_r|all]"
+        exit 1
+        ;;
+esac
+
+echo "Done!"

--- a/benchmarks/spec_runner.go
+++ b/benchmarks/spec_runner.go
@@ -59,6 +59,14 @@ func GetSPECBenchmarks() []SPECBenchmark {
 			TestInputFiles: []string{"test.txt"},
 			WorkingDir:     "benchspec/CPU/531.deepsjeng_r/run/run_base_test_arm64.0000",
 		},
+		{
+			Name:           "548.exchange2_r",
+			Binary:         "benchspec/CPU/548.exchange2_r/exe/exchange2_r_base.arm64",
+			Description:    "Sudoku puzzle solver using Fortran 95 array operations",
+			TestArgs:       []string{"0"},
+			TestInputFiles: []string{"puzzles.txt"},
+			WorkingDir:     "benchspec/CPU/548.exchange2_r/run/run_base_test_arm64.0000",
+		},
 	}
 }
 


### PR DESCRIPTION
## Summary

- Installs `musl-cross` (`aarch64-linux-musl-gcc`) for C/C++ ARM64 Linux cross-compilation
- Compiles three SPEC CPU 2017 benchmarks as static ARM64 Linux ELF binaries:
  - **505.mcf_r** (C) — compiled with `aarch64-linux-musl-gcc -static -O2 -DSPEC -DSPEC_LP64`
  - **531.deepsjeng_r** (C++) — compiled with `aarch64-linux-musl-g++ -static -O2 -DSPEC -DSMALL_MEMORY`
  - **548.exchange2_r** (Fortran) — compiled via Docker Alpine ARM64 with `gfortran -static -no-pie -O2 -DSPEC -cpp`
- Adds `548.exchange2_r` to the SPEC benchmark configuration in `spec_runner.go`
- Adds `build_spec.sh` script documenting all compilation commands

## Context

- Closes #296
- Unblocks #277 (validate 548.exchange2_r execution) and #285 (SPEC benchmarks require ARM64 Linux ELF)
- Binaries are placed in SPEC's `exe/` directories and test run directories are set up with input files
- All binaries verified as `ELF 64-bit LSB executable, ARM aarch64, statically linked`

## Test plan

- [x] `go build ./...` passes
- [x] `go test ./...` passes (all tests including spec_runner_test.go)
- [x] `gofmt` check passes
- [ ] CI lint/build/test

🤖 Generated with [Claude Code](https://claude.com/claude-code)