### PR TITLE
[Athena] Update SPEC.md: H3.2 fast timing PR status

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -170,9 +170,10 @@ SPEC benchmarks will likely exercise ARM64 instructions not yet implemented. Exp
 The full pipeline timing simulation is ~30,000x slower than emulation, making iterative calibration impractical. A "fast timing" mode was developed locally (unmerged) to approximate cycle counts without full pipeline simulation.
 
 **Status:**
-- [x] Fast timing prototype created (`timing/pipeline/fast_timing.go` — local, not yet in a PR)
+- [x] Fast timing prototype created (`timing/pipeline/fast_timing.go`)
 - [x] Instruction limit support added
-- [ ] **Submit fast timing as PR and get it merged** (blocking all calibration work)
+- [x] Fast timing PR submitted (PR #361)
+- [ ] **Fix acceptance test timeout in PR #361 and get it merged** (issue #363 — blocking all calibration work)
 - [ ] Run matrix multiply with fast timing, collect CPI data
 - [ ] Compare fast timing CPI vs full timing CPI vs M2 hardware CPI
 - [ ] Clearly label outputs: simulation speed vs virtual (predicted) time (issue #354)


### PR DESCRIPTION
## Summary
- Updated H3.2 milestone status in SPEC.md to reflect that the fast timing PR has been submitted (PR #361)
- Clarified that the current blocker is the acceptance test timeout (issue #363), not PR submission

## Test plan
- [ ] Verify SPEC.md renders correctly
- [ ] No code changes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)