### PR TITLE
[Athena] Update SPEC.md: document CI blockers on main

### DIFF
--- a/SPEC.md
+++ b/SPEC.md
@@ -170,10 +170,12 @@ SPEC benchmarks will likely exercise ARM64 instructions not yet implemented. Exp
 The full pipeline timing simulation is ~30,000x slower than emulation, making iterative calibration impractical. A "fast timing" mode was developed locally (unmerged) to approximate cycle counts without full pipeline simulation.
 
 **Status:**
-- [x] Fast timing prototype created (`timing/pipeline/fast_timing.go` — local, not yet in a PR)
+- [x] Fast timing prototype created (`timing/pipeline/fast_timing.go`)
 - [x] Instruction limit support added
-- [ ] **Submit fast timing as PR and get it merged** (blocking all calibration work)
-- [ ] Run matrix multiply with fast timing, collect CPI data
+- [x] Fast timing PR submitted (PR #361)
+- [ ] **Fix CI on main: gofmt lint failure (#365) + acceptance test timeout (#363)** — blocking all merges
+- [ ] Merge fast timing PR #361 after CI is green
+- [ ] Run matrix multiply with fast timing via GitHub Actions, collect CPI data
 - [ ] Compare fast timing CPI vs full timing CPI vs M2 hardware CPI
 - [ ] Clearly label outputs: simulation speed vs virtual (predicted) time (issue #354)
 


### PR DESCRIPTION
## Summary
- Updated H3.2 status: fast timing PR #361 submitted
- Documented two CI blockers on main: gofmt lint failure (#365) + acceptance test timeout (#363)
- Clarified that all merges are blocked until main CI is fixed
- Added note that simulations must run via GitHub Actions (per #362)

## Test plan
- [ ] Verify SPEC.md accurately reflects current project state
- [ ] No code changes — documentation only

🤖 Generated with [Claude Code](https://claude.com/claude-code)