### PR TITLE
[Leo] Fix branch misprediction penalty and accuracy_report.py mapping

### DIFF
--- a/benchmarks/native/accuracy_report.py
+++ b/benchmarks/native/accuracy_report.py
@@ -111,7 +111,7 @@ def get_simulator_cpi_for_benchmarks(repo_root: Path) -> dict:
     name_mapping = {
         'arithmetic_sequential': 'arithmetic',
         'dependency_chain': 'dependency',
-        'branch_taken': 'branch',
+        'branch_taken_conditional': 'branch',
     }
     
     # Fallback CPI values if test can't run

--- a/cmd/m2sim/timing_test.go
+++ b/cmd/m2sim/timing_test.go
@@ -206,6 +206,6 @@ var _ = Describe("Timing Model Documentation", func() {
 		Expect(config.LoadLatency).To(Equal(uint64(4)))
 		Expect(config.StoreLatency).To(Equal(uint64(1)))
 		Expect(config.SyscallLatency).To(Equal(uint64(1)))
-		Expect(config.BranchMispredictPenalty).To(Equal(uint64(14)))
+		Expect(config.BranchMispredictPenalty).To(Equal(uint64(12)))
 	})
 })

--- a/timing/latency/config.go
+++ b/timing/latency/config.go
@@ -71,7 +71,7 @@ func DefaultTimingConfig() *TimingConfig {
 	return &TimingConfig{
 		ALULatency:              1,
 		BranchLatency:           1,
-		BranchMispredictPenalty: 14,
+		BranchMispredictPenalty: 12,
 		LoadLatency:             4,
 		StoreLatency:            1,
 		MultiplyLatency:         3,

--- a/timing/latency/latency_test.go
+++ b/timing/latency/latency_test.go
@@ -45,7 +45,7 @@ var _ = Describe("Latency", func() {
 
 		It("should have correct branch misprediction penalty", func() {
 			config := table.Config()
-			Expect(config.BranchMispredictPenalty).To(Equal(uint64(14)))
+			Expect(config.BranchMispredictPenalty).To(Equal(uint64(12)))
 		})
 	})
 


### PR DESCRIPTION
## Summary
- Fix `BranchMispredictPenalty` from 14 to 12 cycles — the config comment already documented 12 as the target for modern OOO cores, but the actual value was 14 (closes #369)
- Fix `accuracy_report.py` benchmark name mapping: `branch_taken` → `branch_taken_conditional` to match the Go test mapping in `accuracy_test.go:75` (closes #371)
- Update corresponding test expectations in `latency_test.go` and `timing_test.go`

## Context
Alex's CPI gap root cause analysis (PR #367) identified the branch misprediction penalty discrepancy as a key contributor to 34.5% branch benchmark error. Reducing from 14 to 12 is expected to cut branch error from ~34.5% to ~25%.

The `accuracy_report.py` fix was identified by Diana (issue #371) — the Go tests correctly use `branch_taken_conditional` but the Python script used `branch_taken`.

## Test plan
- [x] `go build ./...` passes
- [x] `golangci-lint run ./...` passes (zero warnings)
- [x] `go test -short ./...` — all tests pass
- [x] No behavioral changes to pipeline logic (only config value change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)