### PR TITLE
[Leo] Fix fast timing branch handling and delayed-write correctness (#380)

### DIFF
--- a/benchmarks/matmul_calibration_test.go
+++ b/benchmarks/matmul_calibration_test.go
@@ -192,8 +192,6 @@ type MatmulCalibrationResult struct {
 // TestMatmulCalibration runs a 4x4 matrix multiply through the fast timing
 // engine and reports CPI for calibration per issue #359.
 func TestMatmulCalibration(t *testing.T) {
-	t.Skip("MADD/UBFM not yet supported in fast timing decoder — see #380")
-
 	bench := buildMatmul4x4()
 
 	// Run through fast timing


### PR DESCRIPTION
## Summary
- Fix backward branches (B, B.cond, BL) in fast timing engine reading `inst.Imm` (0 for negative offsets) instead of `inst.BranchOffset` — caused infinite loops for any program with backward branches
- Remove broken `pendingOps` delayed-write mechanism that caused dependent instructions to read stale register values (no stall/forwarding model exists). Results now write immediately; multi-cycle latency is tracked via `cycleCount` instead
- Remove stale `t.Skip` in `TestMatmulCalibration` — MADD and UBFM are already supported in the fast timing decoder

## Test plan
- [x] `TestMatmulCalibration` passes: exit code 136, CPI 1.363, 1189 instructions, 1621 cycles
- [x] All pipeline tests pass (`go test ./timing/pipeline/...`)
- [x] All accuracy/CPI comparison tests pass
- [x] All other packages pass (`emu`, `insts`, `loader`, `driver`, etc.)
- [x] Lint clean (`golangci-lint run ./...`)
- [ ] CI workflows green

Closes #380

🤖 Generated with [Claude Code](https://claude.com/claude-code)