### PR TITLE
[Leo] Fix branch prediction for all fetch slots (#385)

### DIFF
--- a/timing/pipeline/superscalar.go
+++ b/timing/pipeline/superscalar.go
@@ -340,6 +340,9 @@ type TertiaryIFIDRegister struct {
 	Valid           bool
 	PC              uint64
 	InstructionWord uint32
+	PredictedTaken  bool
+	PredictedTarget uint64
+	EarlyResolved   bool
 }
 
 // TertiaryIDEXRegister holds the third decoded instruction for 4-wide issue.
@@ -400,6 +403,9 @@ func (r *TertiaryIFIDRegister) Clear() {
 	r.Valid = false
 	r.PC = 0
 	r.InstructionWord = 0
+	r.PredictedTaken = false
+	r.PredictedTarget = 0
+	r.EarlyResolved = false
 }
 
 // Clear resets the tertiary ID/EX register.
@@ -522,6 +528,9 @@ type QuaternaryIFIDRegister struct {
 	Valid           bool
 	PC              uint64
 	InstructionWord uint32
+	PredictedTaken  bool
+	PredictedTarget uint64
+	EarlyResolved   bool
 }
 
 // QuaternaryIDEXRegister holds the fourth decoded instruction for 4-wide issue.
@@ -582,6 +591,9 @@ func (r *QuaternaryIFIDRegister) Clear() {
 	r.Valid = false
 	r.PC = 0
 	r.InstructionWord = 0
+	r.PredictedTaken = false
+	r.PredictedTarget = 0
+	r.EarlyResolved = false
 }
 
 // Clear resets the quaternary ID/EX register.
@@ -704,6 +716,9 @@ type QuinaryIFIDRegister struct {
 	Valid           bool
 	PC              uint64
 	InstructionWord uint32
+	PredictedTaken  bool
+	PredictedTarget uint64
+	EarlyResolved   bool
 }
 
 // QuinaryIDEXRegister holds the decoded instruction for wide issue.
@@ -764,6 +779,9 @@ func (r *QuinaryIFIDRegister) Clear() {
 	r.Valid = false
 	r.PC = 0
 	r.InstructionWord = 0
+	r.PredictedTaken = false
+	r.PredictedTarget = 0
+	r.EarlyResolved = false
 }
 
 // Clear resets the quinary ID/EX register.
@@ -884,6 +902,9 @@ type SenaryIFIDRegister struct {
 	Valid           bool
 	PC              uint64
 	InstructionWord uint32
+	PredictedTaken  bool
+	PredictedTarget uint64
+	EarlyResolved   bool
 }
 
 // SenaryIDEXRegister holds the decoded instruction for wide issue.
@@ -944,6 +965,9 @@ func (r *SenaryIFIDRegister) Clear() {
 	r.Valid = false
 	r.PC = 0
 	r.InstructionWord = 0
+	r.PredictedTaken = false
+	r.PredictedTarget = 0
+	r.EarlyResolved = false
 }
 
 // Clear resets the senary ID/EX register.
@@ -1255,6 +1279,9 @@ type SeptenaryIFIDRegister struct {
 	Valid           bool
 	PC              uint64
 	InstructionWord uint32
+	PredictedTaken  bool
+	PredictedTarget uint64
+	EarlyResolved   bool
 }
 
 // SeptenaryIDEXRegister holds the decoded instruction for wide issue.
@@ -1315,6 +1342,9 @@ func (r *SeptenaryIFIDRegister) Clear() {
 	r.Valid = false
 	r.PC = 0
 	r.InstructionWord = 0
+	r.PredictedTaken = false
+	r.PredictedTarget = 0
+	r.EarlyResolved = false
 }
 
 // Clear resets the septenary ID/EX register.
@@ -1458,6 +1488,9 @@ type OctonaryIFIDRegister struct {
 	Valid           bool
 	PC              uint64
 	InstructionWord uint32
+	PredictedTaken  bool
+	PredictedTarget uint64
+	EarlyResolved   bool
 }
 
 // OctonaryIDEXRegister holds the decoded instruction for wide issue.
@@ -1518,6 +1551,9 @@ func (r *OctonaryIFIDRegister) Clear() {
 	r.Valid = false
 	r.PC = 0
 	r.InstructionWord = 0
+	r.PredictedTaken = false
+	r.PredictedTarget = 0
+	r.EarlyResolved = false
 }
 
 // Clear resets the octonary ID/EX register.


### PR DESCRIPTION
## Summary
- **Fixes #385**: Branch prediction was only applied to fetch slot 0 in wide-issue pipelines (4/6/8-wide). Branches landing in slots 1-7 had no prediction at all, causing guaranteed mispredictions.
- Adds `PredictedTaken`/`PredictedTarget`/`EarlyResolved` fields to Tertiary through Octonary IFID registers
- Applies branch prediction to **all** fetch slots in `tickQuadIssue()`, `tickSextupleIssue()`, and `tickOctupleIssue()` — both for pending (shifted) and newly-fetched instructions
- Propagates prediction fields through the decode stage (IFID → IDEX) for all slots 2-8
- On predicted-taken branches in any slot, redirects fetch to the predicted target and stops filling subsequent slots

## Impact
This is an **architectural correctness fix**. Previously, a branch like `B.GE` landing in slot 1 (after `CMP` in slot 0) would never be predicted, causing a guaranteed misprediction and 2-cycle flush penalty every time. This affected all branch benchmarks in wide-issue mode.

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./timing/pipeline/...` passes locally
- [ ] CI build, test, and lint pass
- [ ] Accuracy report shows improved branch CPI (expect reduction from 22.7% branch error)

🤖 Generated with [Claude Code](https://claude.com/claude-code)