### PR TITLE
[Leo] Separate calibrated vs uncalibrated benchmarks in accuracy report

### DIFF
--- a/benchmarks/native/calibration_results.json
+++ b/benchmarks/native/calibration_results.json
@@ -5,6 +5,7 @@
     {
       "benchmark": "arithmetic",
       "description": "20 independent ADDs per iteration (ALU throughput)",
+      "calibrated": true,
       "instruction_latency_ns": 0.0845121752522325,
       "overhead_ms": 1.95736745580115,
       "r_squared": 0.9999988229822168,
@@ -38,6 +39,7 @@
     {
       "benchmark": "dependency",
       "description": "20 dependent ADDs per iteration (RAW hazards)",
+      "calibrated": true,
       "instruction_latency_ns": 0.31083896341552336,
       "overhead_ms": 2.025789886572037,
       "r_squared": 0.99999963308008,
@@ -71,6 +73,7 @@
     {
       "benchmark": "branch",
       "description": "5 taken branches per iteration (branch predictor)",
+      "calibrated": true,
       "instruction_latency_ns": 0.37242962810330615,
       "overhead_ms": 1.9855502084648744,
       "r_squared": 0.9999953038741262,
@@ -104,34 +107,42 @@
     {
       "benchmark": "memorystrided",
       "description": "10 store/load pairs with stride-4 access (strided memory pattern)",
+      "calibrated": false,
       "instruction_latency_ns": 0.17142857142857143,
       "overhead_ms": 0,
       "r_squared": 0.995,
-      "source": "m2_baseline.json (CPI=0.6 at 3.5 GHz)"
+      "source": "m2_baseline.json (CPI=0.6 at 3.5 GHz)",
+      "uncalibrated_reason": "Analytical estimate, not measured on hardware. Simulator runs without D-cache but baseline assumes cached performance."
     },
     {
       "benchmark": "loadheavy",
       "description": "20 load instructions per iteration (load-heavy workload)",
+      "calibrated": false,
       "instruction_latency_ns": 0.14285714285714285,
       "overhead_ms": 0,
       "r_squared": 0.995,
-      "source": "m2_baseline.json (CPI=0.5 at 3.5 GHz)"
+      "source": "m2_baseline.json (CPI=0.5 at 3.5 GHz)",
+      "uncalibrated_reason": "Analytical estimate, not measured on hardware. Simulator runs without D-cache but baseline assumes cached performance."
     },
     {
       "benchmark": "storeheavy",
       "description": "20 store instructions per iteration (store-heavy workload)",
+      "calibrated": false,
       "instruction_latency_ns": 0.11428571428571428,
       "overhead_ms": 0,
       "r_squared": 0.995,
-      "source": "m2_baseline.json (CPI=0.4 at 3.5 GHz)"
+      "source": "m2_baseline.json (CPI=0.4 at 3.5 GHz)",
+      "uncalibrated_reason": "Analytical estimate, not measured on hardware. Simulator runs without D-cache but baseline assumes cached performance."
     },
     {
       "benchmark": "branchheavy",
       "description": "20 branch instructions per iteration (branch-heavy workload)",
+      "calibrated": false,
       "instruction_latency_ns": 0.2857142857142857,
       "overhead_ms": 0,
       "r_squared": 0.995,
-      "source": "m2_baseline.json (CPI=1.0 at 3.5 GHz)"
+      "source": "m2_baseline.json (CPI=1.0 at 3.5 GHz)",
+      "uncalibrated_reason": "Analytical estimate, not measured on hardware."
     }
   ]
 }


### PR DESCRIPTION
## Summary
- Memory benchmarks (memorystrided, loadheavy, storeheavy) and branchheavy use **analytical CPI estimates** from `m2_baseline.json`, not real hardware measurements
- The simulator runs **without D-cache** but these baselines assume cached performance — making the 350-450% errors misleading
- This PR separates calibrated (hardware-measured) from uncalibrated (analytical) benchmarks so the accuracy summary reflects only reliable data

## Changes
- Added `"calibrated": true/false` field to each entry in `calibration_results.json`
- Report summary now shows **calibrated-only** statistics: ~22.7% avg error (was 175%)
- Uncalibrated benchmarks shown in separate table with explanation
- Normalized chart grays out uncalibrated bars with `*` footnote
- CI exit code threshold based on calibrated benchmarks only

## Root Cause
The 4 new benchmarks added in PR #391 had baselines from `m2_baseline.json` (analytical estimates with CPI 0.4-1.0). These assume real M2 L1 cache hits, but the simulator runs with `EnableDCache = false`. This made them incomparable, inflating the average error from ~22% to ~175%.

## Test plan
- [ ] CI build passes
- [ ] Accuracy report workflow runs and shows calibrated-only summary
- [ ] Verify JSON output includes `calibrated` field per benchmark

🤖 Generated with [Claude Code](https://claude.com/claude-code)