### PR TITLE
[Leo] Scale dependency benchmark to 200 instructions for better accuracy

### DIFF
--- a/benchmarks/microbenchmarks.go
+++ b/benchmarks/microbenchmarks.go
@@ -178,16 +178,20 @@ func arithmetic8Wide() Benchmark {
 }
 
 // 2. Dependency Chain - Tests instruction latency with RAW hazards
+// Uses 200 instructions to amortize pipeline fill/drain overhead (~2% vs ~20%
+// with 20 instructions). Real M2 measures steady-state CPI via regression over
+// millions of iterations, so our benchmark needs enough instructions to make
+// pipeline startup cost negligible.
 func dependencyChain() Benchmark {
 	return Benchmark{
 		Name:        "dependency_chain",
-		Description: "20 dependent ADDs (X0 = X0 + 1) - measures forwarding latency",
+		Description: "200 dependent ADDs (X0 = X0 + 1) - measures forwarding latency",
 		Setup: func(regFile *emu.RegFile, memory *emu.Memory) {
 			regFile.WriteReg(8, 93) // X8 = 93 (exit syscall)
 			regFile.WriteReg(0, 0)  // X0 = 0 (start value)
 		},
-		Program:      buildDependencyChain(20),
-		ExpectedExit: 20, // X0 = 0 + 20*1 = 20
+		Program:      buildDependencyChain(200),
+		ExpectedExit: 200, // X0 = 0 + 200*1 = 200
 	}
 }
 

--- a/benchmarks/timing_harness_test.go
+++ b/benchmarks/timing_harness_test.go
@@ -77,8 +77,8 @@ func TestDependencyChain(t *testing.T) {
 	}
 
 	r := results[0]
-	if r.ExitCode != 20 {
-		t.Errorf("expected exit code 20, got %d", r.ExitCode)
+	if r.ExitCode != 200 {
+		t.Errorf("expected exit code 200, got %d", r.ExitCode)
 	}
 
 	t.Logf("dependency_chain: cycles=%d, insts=%d, CPI=%.3f",


### PR DESCRIPTION
## Summary
- Scale dependency chain benchmark from 20 to 200 instructions to amortize pipeline fill/drain overhead
- Pipeline startup cost drops from ~20% (4 cycles / 20 insts) to ~2% (4 cycles / 200 insts)
- Dependency CPI improves from 1.200 to 1.020, reducing accuracy error from 10.3% to ~6.7%
- Calibrated average error expected to improve from 17.6% to ~16.4%

## Test plan
- [x] Build passes (`go build ./...`)
- [x] `TestDependencyChain` passes with correct exit code (200) and CPI=1.020
- [x] Lint passes
- [ ] CI accuracy report confirms improved dependency error

🤖 Generated with [Claude Code](https://claude.com/claude-code)