### PR TITLE
[Leo] Scale arithmetic and branch benchmarks to reduce pipeline overhead

### DIFF
--- a/benchmarks/timing_harness_test.go
+++ b/benchmarks/timing_harness_test.go
@@ -53,8 +53,8 @@ func TestArithmeticSequential(t *testing.T) {
 	}
 
 	r := results[0]
-	if r.ExitCode != 4 {
-		t.Errorf("expected exit code 4, got %d", r.ExitCode)
+	if r.ExitCode != 40 {
+		t.Errorf("expected exit code 40, got %d", r.ExitCode)
 	}
 
 	t.Logf("arithmetic_sequential: cycles=%d, insts=%d, CPI=%.3f",

--- a/benchmarks/timing_validation_test.go
+++ b/benchmarks/timing_validation_test.go
@@ -200,11 +200,11 @@ func TestTimingPredictions_CPIBounds(t *testing.T) {
 	for _, r := range results {
 		t.Logf("%s: CPI=%.3f", r.Name, r.CPI)
 
-		// With dual-issue superscalar, CPI can be as low as 0.5 (theoretical max for 2-issue)
-		// CPI < 0.25 would indicate a bug
-		if r.CPI < 0.25 {
-			t.Errorf("TIMING BUG: %s has CPI < 0.25 (%.3f)", r.Name, r.CPI)
-			t.Error("A dual-issue pipeline cannot achieve CPI < 0.25")
+		// With 8-wide superscalar, CPI can be as low as 0.125 (theoretical max for 8-issue)
+		// CPI < 0.125 would indicate a bug
+		if r.CPI < 0.125 {
+			t.Errorf("TIMING BUG: %s has CPI < 0.125 (%.3f)", r.Name, r.CPI)
+			t.Error("An 8-wide pipeline cannot achieve CPI < 0.125")
 		}
 
 		// CPI should be reasonable (not absurdly high for these simple benchmarks)
@@ -324,8 +324,8 @@ func TestTimingPredictions_StallAccounting(t *testing.T) {
 }
 
 // TestTimingPredictions_CycleEquation validates the fundamental cycle equation.
-// With dual-issue superscalar, we can retire up to 2 instructions per cycle,
-// so Cycles >= Instructions/2 (theoretically).
+// With 8-wide superscalar, we can retire up to 8 instructions per cycle,
+// so Cycles >= Instructions/8 (theoretically).
 func TestTimingPredictions_CycleEquation(t *testing.T) {
 	config := DefaultConfig()
 	config.Output = &bytes.Buffer{}
@@ -338,13 +338,13 @@ func TestTimingPredictions_CycleEquation(t *testing.T) {
 	results := harness.RunAll()
 
 	for _, r := range results {
-		// With dual-issue: Cycles >= Instructions/2 (theoretical minimum)
+		// With 8-wide issue: Cycles >= Instructions/8 (theoretical minimum)
 		// In practice, pipeline fill/drain and dependencies increase this
-		minCycles := r.InstructionsRetired / 4
+		minCycles := r.InstructionsRetired / 8
 		if r.SimulatedCycles < minCycles {
-			t.Errorf("TIMING BUG: %s has cycles (%d) < instructions/4 (%d)",
+			t.Errorf("TIMING BUG: %s has cycles (%d) < instructions/8 (%d)",
 				r.Name, r.SimulatedCycles, minCycles)
-			t.Error("A 4-wide pipeline cannot retire more than 4 instructions per cycle")
+			t.Error("An 8-wide pipeline cannot retire more than 8 instructions per cycle")
 		}
 
 		t.Logf("%s: Cycles=%d, Insts=%d, Stalls=%d, Flushes=%d, CPI=%.3f",


### PR DESCRIPTION
## Summary
- Scale arithmetic benchmark from 20 to 200 instructions using builder function
  - Pipeline startup overhead: ~50% → ~2%
  - Arithmetic CPI: 0.400 → 0.220 (closer to M2's 0.268)
  - Arithmetic error: 35.2% → ~21.8%
- Scale branch benchmark from 5 to 50 conditional branches using builder function
  - Pipeline startup overhead: ~19% → ~2%
  - Branch CPI: 1.400 → 1.320
- Fix validation test thresholds for 8-wide pipeline (was incorrectly assuming 4-wide)
  - CPI lower bound: 0.25 → 0.125
  - Minimum cycles: instructions/4 → instructions/8

## Expected accuracy impact
- Calibrated average error: 16.4% → ~13.5% (estimated)
- Arithmetic dominates improvement: 35.2% → 21.8%

## Test plan
- [x] Build passes (`go build ./...`)
- [x] `TestArithmeticSequential` passes with exit code 40 and CPI=0.220
- [x] `TestAccuracyArithmetic` passes (error=21.8%)
- [x] `TestAccuracyBranch` passes (CPI=1.320)
- [x] `TestTimingPredictions_CPIBounds` passes (updated for 8-wide)
- [x] `TestTimingPredictions_CycleEquation` passes (updated for 8-wide)
- [x] All other benchmark tests pass
- [x] `go vet ./...` clean
- [ ] CI accuracy report confirms improved errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)