### PR TITLE
[Diana] Add comprehensive tests for fast timing engine

### DIFF
--- a/timing/pipeline/fast_timing_test.go
+++ b/timing/pipeline/fast_timing_test.go
@@ -354,7 +354,7 @@ var _ = Describe("FastTiming", func() {
 				memory.Write32(0x1000, 0xB4000040) // CBZ X0, +8
 				memory.Write32(0x1004, 0x910029E1) // ADD X1, XZR, #10 (skipped)
 				memory.Write32(0x1008, 0xD4000001) // SVC #0
-				regFile.WriteReg(0, 0) // X0 = 0 → branch taken
+				regFile.WriteReg(0, 0)             // X0 = 0 → branch taken
 				regFile.WriteReg(8, 93)
 
 				ft.Run()
@@ -369,7 +369,7 @@ var _ = Describe("FastTiming", func() {
 				memory.Write32(0x1000, 0xB4000040)
 				memory.Write32(0x1004, 0x910029E1) // ADD X1, XZR, #10
 				memory.Write32(0x1008, 0xD4000001) // SVC #0
-				regFile.WriteReg(0, 5) // X0 = 5 → branch not taken
+				regFile.WriteReg(0, 5)             // X0 = 5 → branch not taken
 				regFile.WriteReg(8, 93)
 
 				ft.Run()
@@ -384,7 +384,7 @@ var _ = Describe("FastTiming", func() {
 				memory.Write32(0x1000, 0xB5000040)
 				memory.Write32(0x1004, 0x910029E1) // ADD X1, XZR, #10 (skipped)
 				memory.Write32(0x1008, 0xD4000001) // SVC #0
-				regFile.WriteReg(0, 5) // X0 = 5 → branch taken
+				regFile.WriteReg(0, 5)             // X0 = 5 → branch taken
 				regFile.WriteReg(8, 93)
 
 				ft.Run()
@@ -556,7 +556,7 @@ var _ = Describe("FastTiming", func() {
 
 			// Non-exit syscall then exit syscall
 			memory.Write32(0x1000, 0xD4000001) // SVC #0 (write syscall)
-			regFile.WriteReg(8, 64)             // write syscall number
+			regFile.WriteReg(8, 64)            // write syscall number
 
 			// After the write syscall, modify X8 for exit
 			// But our mock will return non-exited for non-93 syscalls


### PR DESCRIPTION
## Summary
- Fill test coverage gap for `timing/pipeline/fast_timing.go`, which previously had **zero test coverage**
- Add 30+ Ginkgo test cases covering all major FastTiming functionality
- Tests cover: construction, instruction execution (ADD, SUB, LDR, STR, branches, MOVZ, MOVN, AND, ORR, EOR, STP, LDP, CBZ, CBNZ, MADD, LDRB, STRB, LDRH, STRH), max instruction limits, stats tracking, syscall handling, complete program execution, and multi-cycle latency accounting

## Test plan
- [x] All 411 pipeline specs pass locally (`go test ./timing/pipeline/`)
- [x] `go build ./...` passes
- [x] `go vet ./timing/pipeline/` passes
- [ ] CI checks (Build, Lint, Unit Tests, Acceptance Tests) should pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)