### PR TITLE
[Leo] Implement BIC, ORN, EON logical NOT register instructions

### DIFF
--- a/SUPPORTED.md
+++ b/SUPPORTED.md
@@ -32,8 +32,12 @@ This document tracks ARM64 instructions and syscalls supported by M2Sim.
 | SUBS (reg)  | Subtract registers, set flags | ✅ | ✅ |
 | AND (reg)   | Bitwise AND | ✅ | ✅ |
 | ANDS (reg)  | Bitwise AND, set flags | ✅ | ✅ |
+| BIC (reg)   | Bitwise bit clear (AND NOT) | ✅ | ✅ |
+| BICS (reg)  | Bitwise bit clear, set flags | ✅ | ✅ |
 | ORR (reg)   | Bitwise OR | ✅ | ✅ |
+| ORN (reg)   | Bitwise OR NOT | ✅ | ✅ |
 | EOR (reg)   | Bitwise XOR | ✅ | ✅ |
+| EON (reg)   | Bitwise exclusive OR NOT | ✅ | ✅ |
 
 ### Data Processing (2 Source)
 
@@ -253,29 +257,6 @@ The emu package implements the full set of syscalls. The driver package provides
 
 ## Known Limitations
 
-### Logical Register Operations - N-bit Not Handled
-
-**Issue:** The N-bit (bit 21) in logical register instructions is not currently
-decoded. This bit controls whether the second operand (Rm) is inverted before
-the operation.
-
-**Affected Instructions:**
-- **BIC** (Bitwise Bit Clear) - decoded incorrectly as AND
-- **ORN** (Bitwise OR NOT) - decoded incorrectly as ORR
-- **EON** (Bitwise Exclusive OR NOT) - decoded incorrectly as EOR
-
-**Encoding Reference:**
-```
-Logical (shifted register): sf | opc | 01010 | shift | N | Rm | imm6 | Rn | Rd
-                                                       ^
-                                                   bit 21 (N)
-```
-
-When N=1, the Rm value should be bitwise inverted (~Rm) before the logical
-operation is applied. The current decoder ignores this bit.
-
-**Status:** Not implemented. Tracked for future work.
-
 ### Missing Test Coverage
 
 The following areas lack test coverage:
@@ -286,5 +267,5 @@ The following areas lack test coverage:
 
 ---
 
-*Last updated: 2026-02-08*
+*Last updated: 2026-02-10*
 *Consolidated from root SUPPORTED.md and insts/SUPPORTED.md*

--- a/emu/emulator.go
+++ b/emu/emulator.go
@@ -462,6 +462,44 @@ func (e *Emulator) executeDPReg(inst *insts.Instruction) {
 			op2 := applyShift32(uint32(e.regFile.ReadReg(inst.Rm)), inst.ShiftType, inst.ShiftAmount)
 			e.regFile.WriteReg(inst.Rd, uint64(op1^op2))
 		}
+	case insts.OpBIC:
+		if inst.Is64Bit {
+			op1 := e.regFile.ReadReg(inst.Rn)
+			op2 := applyShift64(e.regFile.ReadReg(inst.Rm), inst.ShiftType, inst.ShiftAmount)
+			result := op1 & ^op2
+			e.regFile.WriteReg(inst.Rd, result)
+			if inst.SetFlags {
+				e.alu.setLogicFlags64(result)
+			}
+		} else {
+			op1 := uint32(e.regFile.ReadReg(inst.Rn))
+			op2 := applyShift32(uint32(e.regFile.ReadReg(inst.Rm)), inst.ShiftType, inst.ShiftAmount)
+			result := op1 & ^op2
+			e.regFile.WriteReg(inst.Rd, uint64(result))
+			if inst.SetFlags {
+				e.alu.setLogicFlags32(result)
+			}
+		}
+	case insts.OpORN:
+		if inst.Is64Bit {
+			op1 := e.regFile.ReadReg(inst.Rn)
+			op2 := applyShift64(e.regFile.ReadReg(inst.Rm), inst.ShiftType, inst.ShiftAmount)
+			e.regFile.WriteReg(inst.Rd, op1|^op2)
+		} else {
+			op1 := uint32(e.regFile.ReadReg(inst.Rn))
+			op2 := applyShift32(uint32(e.regFile.ReadReg(inst.Rm)), inst.ShiftType, inst.ShiftAmount)
+			e.regFile.WriteReg(inst.Rd, uint64(op1|^op2))
+		}
+	case insts.OpEON:
+		if inst.Is64Bit {
+			op1 := e.regFile.ReadReg(inst.Rn)
+			op2 := applyShift64(e.regFile.ReadReg(inst.Rm), inst.ShiftType, inst.ShiftAmount)
+			e.regFile.WriteReg(inst.Rd, op1^^op2)
+		} else {
+			op1 := uint32(e.regFile.ReadReg(inst.Rn))
+			op2 := applyShift32(uint32(e.regFile.ReadReg(inst.Rm)), inst.ShiftType, inst.ShiftAmount)
+			e.regFile.WriteReg(inst.Rd, uint64(op1^^op2))
+		}
 	}
 }
 

--- a/insts/decoder_test.go
+++ b/insts/decoder_test.go
@@ -282,6 +282,69 @@ var _ = Describe("Decoder", func() {
 			Expect(inst.Rn).To(Equal(uint8(19)))
 			Expect(inst.Rm).To(Equal(uint8(20)))
 		})
+
+		// BIC X0, X1, X2     -> 0x8A220020
+		// Encoding: sf=1, opc=00, 01010, shift=00, N=1, Rm=2, imm6=0, Rn=1, Rd=0
+		It("should decode BIC X0, X1, X2", func() {
+			inst := decoder.Decode(0x8A220020)
+
+			Expect(inst.Op).To(Equal(insts.OpBIC))
+			Expect(inst.Is64Bit).To(BeTrue())
+			Expect(inst.SetFlags).To(BeFalse())
+			Expect(inst.Rd).To(Equal(uint8(0)))
+			Expect(inst.Rn).To(Equal(uint8(1)))
+			Expect(inst.Rm).To(Equal(uint8(2)))
+			Expect(inst.Format).To(Equal(insts.FormatDPReg))
+		})
+
+		// BIC W0, W1, W2     -> 0x0A220020
+		// Encoding: sf=0, opc=00, 01010, shift=00, N=1, Rm=2, imm6=0, Rn=1, Rd=0
+		It("should decode BIC W0, W1, W2", func() {
+			inst := decoder.Decode(0x0A220020)
+
+			Expect(inst.Op).To(Equal(insts.OpBIC))
+			Expect(inst.Is64Bit).To(BeFalse())
+			Expect(inst.SetFlags).To(BeFalse())
+		})
+
+		// ORN X3, X4, X5     -> 0xAA250083
+		// Encoding: sf=1, opc=01, 01010, shift=00, N=1, Rm=5, imm6=0, Rn=4, Rd=3
+		It("should decode ORN X3, X4, X5", func() {
+			inst := decoder.Decode(0xAA250083)
+
+			Expect(inst.Op).To(Equal(insts.OpORN))
+			Expect(inst.Is64Bit).To(BeTrue())
+			Expect(inst.SetFlags).To(BeFalse())
+			Expect(inst.Rd).To(Equal(uint8(3)))
+			Expect(inst.Rn).To(Equal(uint8(4)))
+			Expect(inst.Rm).To(Equal(uint8(5)))
+		})
+
+		// EON X6, X7, X8     -> 0xCA2800E6
+		// Encoding: sf=1, opc=10, 01010, shift=00, N=1, Rm=8, imm6=0, Rn=7, Rd=6
+		It("should decode EON X6, X7, X8", func() {
+			inst := decoder.Decode(0xCA2800E6)
+
+			Expect(inst.Op).To(Equal(insts.OpEON))
+			Expect(inst.Is64Bit).To(BeTrue())
+			Expect(inst.SetFlags).To(BeFalse())
+			Expect(inst.Rd).To(Equal(uint8(6)))
+			Expect(inst.Rn).To(Equal(uint8(7)))
+			Expect(inst.Rm).To(Equal(uint8(8)))
+		})
+
+		// BICS X9, X10, X11  -> 0xEA2B0149
+		// Encoding: sf=1, opc=11, 01010, shift=00, N=1, Rm=11, imm6=0, Rn=10, Rd=9
+		It("should decode BICS X9, X10, X11", func() {
+			inst := decoder.Decode(0xEA2B0149)
+
+			Expect(inst.Op).To(Equal(insts.OpBIC))
+			Expect(inst.Is64Bit).To(BeTrue())
+			Expect(inst.SetFlags).To(BeTrue())
+			Expect(inst.Rd).To(Equal(uint8(9)))
+			Expect(inst.Rn).To(Equal(uint8(10)))
+			Expect(inst.Rm).To(Equal(uint8(11)))
+		})
 	})
 
 	Describe("Branch Instructions", func() {

--- a/timing/latency/latency.go
+++ b/timing/latency/latency.go
@@ -35,7 +35,8 @@ func (t *Table) GetLatency(inst *insts.Instruction) uint64 {
 	}
 
 	switch inst.Op {
-	case insts.OpADD, insts.OpSUB, insts.OpAND, insts.OpORR, insts.OpEOR:
+	case insts.OpADD, insts.OpSUB, insts.OpAND, insts.OpORR, insts.OpEOR,
+		insts.OpBIC, insts.OpORN, insts.OpEON:
 		return t.config.ALULatency
 
 	case insts.OpB, insts.OpBL, insts.OpBCond, insts.OpBR, insts.OpBLR, insts.OpRET:

--- a/timing/pipeline/fast_timing.go
+++ b/timing/pipeline/fast_timing.go
@@ -285,6 +285,24 @@ func (ft *FastTiming) executeInstruction(inst *insts.Instruction, pc uint64) {
 			writeValue = rnValue ^ inst.Imm
 		}
 
+	case insts.OpBIC:
+		instLatency = ft.latencyTable.GetLatency(inst)
+		writeReg = inst.Rd
+		writeValue = rnValue & ^rmValue
+		if inst.SetFlags {
+			ft.updateFlagsLogical(writeValue, inst.Is64Bit)
+		}
+
+	case insts.OpORN:
+		instLatency = ft.latencyTable.GetLatency(inst)
+		writeReg = inst.Rd
+		writeValue = rnValue | ^rmValue
+
+	case insts.OpEON:
+		instLatency = ft.latencyTable.GetLatency(inst)
+		writeReg = inst.Rd
+		writeValue = rnValue ^ ^rmValue
+
 	case insts.OpRET:
 		targetAddr := ft.regFile.ReadReg(30)
 		ft.PC = targetAddr

--- a/timing/pipeline/stages.go
+++ b/timing/pipeline/stages.go
@@ -112,7 +112,8 @@ func (s *DecodeStage) isRegWriteInst(inst *insts.Instruction) bool {
 	}
 
 	switch inst.Op {
-	case insts.OpADD, insts.OpSUB, insts.OpAND, insts.OpORR, insts.OpEOR:
+	case insts.OpADD, insts.OpSUB, insts.OpAND, insts.OpORR, insts.OpEOR,
+		insts.OpBIC, insts.OpORN, insts.OpEON:
 		return true
 	case insts.OpLDR, insts.OpLDP, insts.OpLDRB, insts.OpLDRSB,
 		insts.OpLDRH, insts.OpLDRSH, insts.OpLDRLit, insts.OpLDRQ:
@@ -216,6 +217,12 @@ func (s *ExecuteStage) ExecuteWithFlags(idex *IDEXRegister, rnValue, rmValue uin
 		result.ALUResult = s.executeORR(inst, rnValue, rmValue)
 	case insts.OpEOR:
 		result.ALUResult = s.executeEOR(inst, rnValue, rmValue)
+	case insts.OpBIC:
+		result.ALUResult = s.executeBIC(inst, rnValue, rmValue)
+	case insts.OpORN:
+		result.ALUResult = s.executeORN(inst, rnValue, rmValue)
+	case insts.OpEON:
+		result.ALUResult = s.executeEON(inst, rnValue, rmValue)
 	case insts.OpLDR, insts.OpSTR, insts.OpLDP, insts.OpSTP,
 		insts.OpLDRB, insts.OpSTRB, insts.OpLDRSB,
 		insts.OpLDRH, insts.OpSTRH, insts.OpLDRSH:
@@ -393,6 +400,27 @@ func (s *ExecuteStage) executeEOR(inst *insts.Instruction, rnValue, rmValue uint
 		return rnValue ^ rmValue
 	}
 	return uint64(uint32(rnValue) ^ uint32(rmValue))
+}
+
+func (s *ExecuteStage) executeBIC(inst *insts.Instruction, rnValue, rmValue uint64) uint64 {
+	if inst.Is64Bit {
+		return rnValue & ^rmValue
+	}
+	return uint64(uint32(rnValue) & ^uint32(rmValue))
+}
+
+func (s *ExecuteStage) executeORN(inst *insts.Instruction, rnValue, rmValue uint64) uint64 {
+	if inst.Is64Bit {
+		return rnValue | ^rmValue
+	}
+	return uint64(uint32(rnValue) | ^uint32(rmValue))
+}
+
+func (s *ExecuteStage) executeEON(inst *insts.Instruction, rnValue, rmValue uint64) uint64 {
+	if inst.Is64Bit {
+		return rnValue ^ ^rmValue
+	}
+	return uint64(uint32(rnValue) ^ ^uint32(rmValue))
 }
 
 // computeAddFlags computes PSTATE flags for an ADD/ADDS operation without setting them.


### PR DESCRIPTION
## Summary
- Implement ARM64 logical NOT register operations: BIC (Bit Clear), BICS, ORN (OR NOT), EON (Exclusive OR NOT)
- Decode N-bit (bit 21) in logical shifted register encoding to distinguish AND/BIC, ORR/ORN, EOR/EON, ANDS/BICS
- Add execution support in emulator, timing pipeline, fast timing engine, and latency table
- Remove "Logical Register Operations - N-bit Not Handled" known limitation from SUPPORTED.md

## Test plan
- [x] Decoder tests for BIC (64/32-bit), ORN, EON, BICS — all pass
- [x] All existing tests pass (`insts`, `emu`, `timing/pipeline`, `timing/latency`)
- [x] Build succeeds (`go build ./...`)
- [ ] CI verification (build, lint, unit tests, acceptance tests)

Toward #398 (SPEC 548.exchange2_r validation).

🤖 Generated with [Claude Code](https://claude.com/claude-code)