### PR TITLE
[Leo] Fix SPEC workflow report generation and failure reporting

### DIFF
--- a/.github/workflows/spec-bench.yml
+++ b/.github/workflows/spec-bench.yml
@@ -58,39 +58,43 @@ jobs:
           fi
 
       - name: Run SPEC benchmarks
+        id: spec-run
         if: steps.spec-check.outputs.spec_available == 'true'
         run: |
           echo "Running SPEC benchmark validation..."
-          
+
           # Run SPEC tests with extended timeout
-          go test -v -timeout 3h ./benchmarks/... -run TestSPEC || {
+          if go test -v -timeout 3h ./benchmarks/... -run TestSPEC; then
+            echo "spec_passed=true" >> $GITHUB_OUTPUT
+          else
             echo "⚠️ Some SPEC tests failed or timed out"
-            exit 0  # Don't fail workflow on test failures
-          }
+            echo "spec_passed=false" >> $GITHUB_OUTPUT
+          fi
 
       - name: Generate SPEC accuracy report
         if: steps.spec-check.outputs.spec_available == 'true'
         run: |
           mkdir -p reports/spec
-          
-          # Generate report (placeholder - actual report generation TBD)
-          cat > reports/spec/spec-report.md << 'EOF'
+          REPORT_DATE=$(date -u +"%Y-%m-%d %H:%M UTC")
+          SPEC_STATUS="${{ steps.spec-run.outputs.spec_passed }}"
+
+          cat > reports/spec/spec-report.md << EOF
           # SPEC Benchmark Report
-          
-          Generated: $(date -u +"%Y-%m-%d %H:%M UTC")
-          
+
+          Generated: ${REPORT_DATE}
+
           ## Status
-          
-          SPEC benchmark infrastructure is set up.
+
+          Tests passed: ${SPEC_STATUS}
           See workflow logs for detailed results.
-          
+
           ## Notes
-          
+
           - Running on: ${{ runner.os }} / ${{ runner.arch }}
           - Timeout: 4 hours
-          - Benchmarks: 557.xz_r, 505.mcf_r, 531.deepsjeng_r
+          - Benchmarks: 548.exchange2_r, 557.xz_r, 505.mcf_r, 531.deepsjeng_r
           EOF
-          
+
           echo "Report generated at reports/spec/spec-report.md"
 
       - name: Upload SPEC Report
@@ -108,9 +112,9 @@ jobs:
           echo "" >> $GITHUB_STEP_SUMMARY
           echo "- **Date:** $(date -u +"%Y-%m-%d %H:%M UTC")" >> $GITHUB_STEP_SUMMARY
           echo "- **SPEC Available:** ${{ steps.spec-check.outputs.spec_available }}" >> $GITHUB_STEP_SUMMARY
-          echo "" >> $GITHUB_STEP_SUMMARY
-          
+
           if [ "${{ steps.spec-check.outputs.spec_available }}" != "true" ]; then
+            echo "" >> $GITHUB_STEP_SUMMARY
             echo "⚠️ **SPEC not installed on this runner.**" >> $GITHUB_STEP_SUMMARY
             echo "" >> $GITHUB_STEP_SUMMARY
             echo "To enable SPEC benchmarks:" >> $GITHUB_STEP_SUMMARY
@@ -118,5 +122,14 @@ jobs:
             echo "2. Run \`scripts/spec-setup.sh link\` to create the symlink" >> $GITHUB_STEP_SUMMARY
             echo "3. Run \`scripts/spec-setup.sh build\` to compile ARM64 binaries" >> $GITHUB_STEP_SUMMARY
           else
+            SPEC_PASSED="${{ steps.spec-run.outputs.spec_passed }}"
+            echo "- **Tests Passed:** ${SPEC_PASSED}" >> $GITHUB_STEP_SUMMARY
+            echo "" >> $GITHUB_STEP_SUMMARY
+            if [ "${SPEC_PASSED}" != "true" ]; then
+              echo "⚠️ **Some SPEC tests failed.** Check workflow logs for details." >> $GITHUB_STEP_SUMMARY
+            else
+              echo "✅ All SPEC tests passed." >> $GITHUB_STEP_SUMMARY
+            fi
+            echo "" >> $GITHUB_STEP_SUMMARY
             echo "See artifacts for detailed benchmark results." >> $GITHUB_STEP_SUMMARY
           fi


### PR DESCRIPTION
## Summary
- Fix heredoc quoting in spec-bench.yml so `$(date)` and shell variables interpolate correctly in generated reports (was using single-quoted `'EOF'`)
- Replace `exit 0` on test failure with proper pass/fail status capture via `GITHUB_OUTPUT`
- Surface SPEC test pass/fail results in the workflow step summary
- Add 548.exchange2_r to benchmark list in report template

Addresses QA feedback from Diana on issue #307.

## Test plan
- [ ] Workflow YAML syntax validates (CI checks)
- [ ] When SPEC is not available, behavior unchanged (skip gracefully)
- [ ] When SPEC is available, report correctly shows date and pass/fail status
- [ ] Step summary now distinguishes between pass and failure

🤖 Generated with [Claude Code](https://claude.com/claude-code)