### PR TITLE
[Leo] Fix memory calibration workflow dispatch registration

### DIFF
--- a/.github/workflows/memory-bench-calibration.yml
+++ b/.github/workflows/memory-bench-calibration.yml
@@ -2,12 +2,11 @@ name: Memory Subsystem Calibration
 
 on:
   workflow_dispatch:
-    # Manual trigger - calibration is expensive
 
 jobs:
   calibrate:
     name: Run Memory Calibration on Apple Silicon
-    runs-on: macos-14  # Apple Silicon runner
+    runs-on: macos-14
     timeout-minutes: 60
 
     steps:
@@ -49,21 +48,6 @@ jobs:
             echo '```json' >> $GITHUB_STEP_SUMMARY
             cat benchmarks/native/memory_calibration_results.json >> $GITHUB_STEP_SUMMARY
             echo '```' >> $GITHUB_STEP_SUMMARY
-
-            # Extract CPI values for summary
-            echo "" >> $GITHUB_STEP_SUMMARY
-            echo "### CPI Summary (at 3.5 GHz)" >> $GITHUB_STEP_SUMMARY
-            echo "" >> $GITHUB_STEP_SUMMARY
-            python3 -c "
-import json
-with open('benchmarks/native/memory_calibration_results.json') as f:
-    data = json.load(f)
-print('| Benchmark | Latency (ns) | CPI | R² |')
-print('|-----------|-------------|-----|-----|')
-for r in data['results']:
-    cpi = r['instruction_latency_ns'] * 3.5
-    print(f'| {r[\"benchmark\"]} | {r[\"instruction_latency_ns\"]:.4f} | {cpi:.3f} | {r[\"r_squared\"]:.6f} |')
-" >> $GITHUB_STEP_SUMMARY
           else
             echo "Calibration results not found." >> $GITHUB_STEP_SUMMARY
           fi


### PR DESCRIPTION
## Summary
- GitHub never properly parsed the `memory-calibration.yml` YAML, causing `workflow_dispatch` trigger to not register (HTTP 422 on dispatch attempts)
- Evidence: workflow `name` field shows as `.github/workflows/memory-calibration.yml` instead of `Memory Subsystem Calibration` in the API
- Fix: rename to `memory-bench-calibration.yml` and simplify YAML (remove inline Python, strip comments) to force GitHub to create a fresh workflow ID with proper parsing

## Context
- Unblocks #413 (memory subsystem calibration execution)
- Previous fix attempt (PR #416) merged but did not resolve the dispatch issue

## Test plan
- [ ] After merge, verify new workflow appears with correct name in `gh workflow list`
- [ ] Verify `gh workflow run memory-bench-calibration.yml` succeeds
- [ ] Trigger Memory Subsystem Calibration to collect baselines

🤖 Generated with [Claude Code](https://claude.com/claude-code)