### PR TITLE
[Leo] Add branch_heavy to accuracy test mapping

### DIFF
--- a/benchmarks/accuracy_test.go
+++ b/benchmarks/accuracy_test.go
@@ -69,10 +69,13 @@ type AccuracySummary struct {
 
 // benchmarkMapping maps simulator benchmark names to baseline names.
 // Uses branch_taken_conditional to match native benchmark pattern (CMP + B.GE).
+// Memory-latency benchmarks (loadheavy, storeheavy, memorystrided) require
+// D-cache for meaningful comparison — see dcache_accuracy_test.go (PR #429).
 var benchmarkMapping = map[string]string{
 	"arithmetic_sequential":    "arithmetic",
 	"dependency_chain":         "dependency",
 	"branch_taken_conditional": "branch",
+	"branch_heavy":             "branchheavy",
 }
 
 // loadBaseline loads the M2 baseline data from the native directory.


### PR DESCRIPTION
## Summary
- Expands accuracy test coverage from 3 to 4 benchmarks by wiring `branch_heavy` to the `branchheavy` baseline
- Current result: sim CPI 0.829 vs baseline CPI 1.0 (20.7% error)
- Memory-latency benchmarks (loadheavy, storeheavy, memorystrided) require D-cache — deferred to PR #429's `dcache_accuracy_test.go`

## Test plan
- [x] `go build ./...` passes
- [x] `go test ./benchmarks/ -short` passes
- [x] `TestAccuracyAgainstBaseline` runs with 4 benchmarks (was 3)
- [x] `go test ./emu/... ./timing/...` all pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)