### PR TITLE
[Leo] Add PolyBench simulation measurements via GitHub Actions

### DIFF
--- a/.github/workflows/polybench-sim.yml
+++ b/.github/workflows/polybench-sim.yml
@@ -1,0 +1,126 @@
+name: PolyBench Simulation Measurements
+
+on:
+  workflow_dispatch:
+  push:
+    branches: [main]
+    paths:
+      - 'benchmarks/polybench_test.go'
+      - 'benchmarks/timing_harness.go'
+      - 'timing/**'
+
+jobs:
+  polybench-sim:
+    name: Run PolyBench Timing Simulations
+    runs-on: ubuntu-latest
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: '1.25'
+
+      - name: Verify PolyBench ELFs exist
+        run: |
+          echo "Checking PolyBench ELF files..."
+          ls -la benchmarks/polybench/*.elf
+          echo ""
+          echo "ELF count: $(ls benchmarks/polybench/*.elf 2>/dev/null | wc -l)"
+
+      - name: Run PolyBench timing simulations
+        id: sim
+        run: |
+          echo "Running all 7 PolyBench benchmarks in timing mode..."
+          echo ""
+
+          # Run all PolyBench tests (no -short flag so they actually execute)
+          go test -v -run "TestPolybench" -count=1 -timeout 20m ./benchmarks/ 2>&1 | tee polybench_output.txt
+
+          echo ""
+          echo "=== Raw CPI Output ==="
+          grep "CPI=" polybench_output.txt || echo "No CPI lines found"
+
+      - name: Extract CPI results as JSON
+        run: |
+          python3 - <<'PYEOF'
+          import json
+          import re
+          import sys
+
+          results = {}
+          with open("polybench_output.txt") as f:
+              for line in f:
+                  # Match lines like: polybench_atax: cycles=1234, insts=5678, CPI=1.234, ...
+                  if "CPI=" not in line:
+                      continue
+                  # Extract benchmark name and CPI
+                  match = re.search(r'(polybench_\w+):\s+cycles=(\d+),\s+insts=(\d+),\s+CPI=([\d.]+)', line)
+                  if match:
+                      name = match.group(1)
+                      cycles = int(match.group(2))
+                      insts = int(match.group(3))
+                      cpi = float(match.group(4))
+                      # Map polybench_X -> X for calibration naming
+                      short_name = name.replace("polybench_", "")
+                      # Fix jacobi1d -> jacobi-1d
+                      if short_name == "jacobi1d":
+                          short_name = "jacobi-1d"
+                      results[short_name] = {
+                          "sim_name": name,
+                          "cycles": cycles,
+                          "instructions": insts,
+                          "cpi": cpi,
+                      }
+
+          output = {
+              "source": "polybench_timing_simulation",
+              "benchmarks_run": len(results),
+              "results": results,
+          }
+
+          with open("polybench_sim_cpis.json", "w") as f:
+              json.dump(output, f, indent=2)
+
+          print(json.dumps(output, indent=2))
+
+          if len(results) == 0:
+              print("\nERROR: No PolyBench CPI results extracted!", file=sys.stderr)
+              sys.exit(1)
+
+          print(f"\nSuccessfully extracted {len(results)} PolyBench CPI values")
+          PYEOF
+
+      - name: Post results summary
+        if: always()
+        run: |
+          echo "## PolyBench Simulation Results" >> $GITHUB_STEP_SUMMARY
+          echo "" >> $GITHUB_STEP_SUMMARY
+
+          if [ -f polybench_sim_cpis.json ]; then
+            python3 -c "
+          import json
+          d = json.load(open('polybench_sim_cpis.json'))
+          print(f'**Benchmarks measured:** {d[\"benchmarks_run\"]}/7')
+          print()
+          print('| Benchmark | Cycles | Instructions | CPI |')
+          print('|-----------|--------|--------------|-----|')
+          for name, r in sorted(d['results'].items()):
+              print(f'| {name} | {r[\"cycles\"]} | {r[\"instructions\"]} | {r[\"cpi\"]:.3f} |')
+          " >> $GITHUB_STEP_SUMMARY
+          else
+            echo "No results generated." >> $GITHUB_STEP_SUMMARY
+          fi
+
+      - name: Upload CPI results
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: polybench-sim-results
+          path: |
+            polybench_sim_cpis.json
+            polybench_output.txt
+          retention-days: 90


### PR DESCRIPTION
## Summary
- Adds `polybench-sim.yml` workflow that runs all 7 PolyBench benchmarks in timing mode and exports CPI values as JSON artifact
- Fixes `h5_accuracy_report.py` to run actual PolyBench Go tests instead of using hardcoded dummy CPI values (0.4-0.7 range was causing ~986,000% error)
- Fallback CPI values updated to conservative estimates (1.0-5.0) only used if Go test execution fails

## Test plan
- [ ] Verify `polybench-sim.yml` workflow runs successfully and produces `polybench_sim_cpis.json` artifact
- [ ] Verify H5 accuracy report workflow now outputs real CPI measurements instead of dummy values
- [ ] Confirm all 7 PolyBench tests (atax, bicg, mvt, jacobi-1d, gemm, 2mm, 3mm) produce realistic CPI (expected: 1.0-10.0 range)

Closes #464

🤖 Generated with [Claude Code](https://claude.com/claude-code)