### PR TITLE
[Quinn] Fix CI Health Monitor infrastructure failure

### DIFF
--- a/.github/workflows/ci-health-monitor.yml
+++ b/.github/workflows/ci-health-monitor.yml
@@ -52,13 +52,13 @@ jobs:
 
               return recent_runs
 
-          # Critical workflows to monitor
+          # Critical workflows to monitor (using display names from workflow YAML)
           workflows = [
-              'ci.yml',
-              'h5-accuracy-report.yml',
-              'polybench-sim.yml',
-              'cpi-comparison.yml',
-              'matmul-calibration.yml'
+              'CI',
+              'H5 Accuracy Report',
+              'PolyBench Simulation Measurements',
+              'CPI Comparison',
+              'Matmul Calibration'
           ]
 
           health_report = {
@@ -161,8 +161,8 @@ jobs:
               """Check if critical workflows have run recently enough"""
               alerts = []
 
-              # Workflows that should run on every push to main
-              critical_workflows = ['ci.yml', 'h5-accuracy-report.yml']
+              # Workflows that should run on every push to main (using display names)
+              critical_workflows = ['CI', 'H5 Accuracy Report']
 
               # Get recent commits to main
               result = subprocess.run(['git', 'log', '--since=1 day ago', '--oneline', 'main'],


### PR DESCRIPTION
## Summary

Fixes critical CI Health Monitor workflow failure that was preventing proactive CI infrastructure monitoring.

## Problem

- CI Health Monitor workflow was failing with exit code 1
- All monitored workflows showing "no_data" status  
- Script was using YAML filenames (e.g., `ci.yml`) instead of workflow display names (e.g., `CI`)
- GitHub CLI `gh run list --workflow` expects display names, not filenames

## Solution

- Updated workflow identifiers from YAML filenames to display names:
  - `ci.yml` → `CI`
  - `h5-accuracy-report.yml` → `H5 Accuracy Report`
  - `polybench-sim.yml` → `PolyBench Simulation Measurements`
  - `cpi-comparison.yml` → `CPI Comparison`
  - `matmul-calibration.yml` → `Matmul Calibration`

## Test Plan

- [x] Manual workflow trigger to verify fix works
- [ ] Monitor next scheduled run (every 6 hours) for success
- [ ] Verify workflow data collection is restored

## Impact

- Restores CI health monitoring capability
- Enables proactive detection of CI infrastructure issues  
- Supports quality assurance and development velocity

🤖 Generated with [Claude Code](https://claude.com/claude-code)