### PR TITLE
[Athena] Fix CI timeout: skip accuracy tests in short mode

### DIFF
--- a/benchmarks/accuracy_test.go
+++ b/benchmarks/accuracy_test.go
@@ -137,6 +137,10 @@ func calculateError(simCPI, baselineCPI float64) float64 {
 // TestAccuracyAgainstBaseline compares simulator results against M2 baseline.
 // This is the main accuracy validation test for M2Sim.
 func TestAccuracyAgainstBaseline(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running accuracy test in short mode")
+	}
+
 	// Load baseline data
 	baseline := loadBaseline(t)
 
@@ -212,6 +216,10 @@ func TestAccuracyAgainstBaseline(t *testing.T) {
 // TestAccuracyDependencyChain specifically tests the dependency chain accuracy.
 // This is critical because it measures the simulator's handling of RAW hazards.
 func TestAccuracyDependencyChain(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running accuracy test in short mode")
+	}
+
 	baseline := loadBaseline(t)
 	baselineEntry := findBaseline(baseline, "dependency")
 	if baselineEntry == nil {
@@ -249,6 +257,10 @@ func TestAccuracyDependencyChain(t *testing.T) {
 
 // TestAccuracyArithmetic tests ALU throughput accuracy.
 func TestAccuracyArithmetic(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running accuracy test in short mode")
+	}
+
 	baseline := loadBaseline(t)
 	baselineEntry := findBaseline(baseline, "arithmetic")
 	if baselineEntry == nil {
@@ -280,6 +292,10 @@ func TestAccuracyArithmetic(t *testing.T) {
 // TestAccuracyBranch tests branch handling accuracy using conditional branches.
 // Uses branchTakenConditional to match native benchmark pattern (CMP + B.GE).
 func TestAccuracyBranch(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running accuracy test in short mode")
+	}
+
 	baseline := loadBaseline(t)
 	baselineEntry := findBaseline(baseline, "branch")
 	if baselineEntry == nil {
@@ -373,6 +389,10 @@ func GenerateAccuracyReport(t *testing.T) AccuracyReport {
 
 // TestGenerateAccuracyReport tests the report generation and outputs JSON.
 func TestGenerateAccuracyReport(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skipping long-running accuracy report generation in short mode")
+	}
+
 	report := GenerateAccuracyReport(t)
 
 	reportJSON, err := json.MarshalIndent(report, "", "  ")


### PR DESCRIPTION
## Summary
- Add `testing.Short()` skip to all 5 accuracy tests in `benchmarks/accuracy_test.go`
- CI passes `-short` flag but these tests didn't check it, causing the Acceptance Tests job to timeout (>5min) on every push
- `medium_test.go` and `polybench_test.go` already had this pattern; `accuracy_test.go` was the only file missing it

## Impact
This is the **#1 CI blocker** — every push to main fails because `TestAccuracyAgainstBaseline` runs 25+ full pipeline simulations. With this fix, CI should pass for the first time.

## Test plan
- [ ] CI Acceptance Tests job completes within 5min timeout
- [ ] PRs #507 and #500 (previously blocked by CI failure) can proceed

## Tests affected
- `TestAccuracyAgainstBaseline` — skipped in short mode
- `TestAccuracyDependencyChain` — skipped in short mode
- `TestAccuracyArithmetic` — skipped in short mode
- `TestAccuracyBranch` — skipped in short mode
- `TestGenerateAccuracyReport` — skipped in short mode

These tests still run in the dedicated accuracy workflows (`accuracy-report.yml`, `h5-accuracy-report.yml`) which don't pass `-short`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)